### PR TITLE
Rule: A LRO must have extension enabled

### DIFF
--- a/src/dotnet/OpenAPI.Validator.Tests/OpenAPIModelerValidationTests.cs
+++ b/src/dotnet/OpenAPI.Validator.Tests/OpenAPIModelerValidationTests.cs
@@ -619,6 +619,20 @@ namespace OpenAPI.Validator.Tests
             var messages = GetValidationMessagesForRule<LocationMustHaveXmsMutability>("location-with-incorrect-xms-mutability.json");
             Assert.Equal(messages.Count(), 1);
         }
+
+        [Fact]
+        public void LongRunningHasExtensionValidation()
+        {
+            var messages = GetValidationMessagesForRule<LongRunningOperationsWithLongRunningExtension>("long-running-operation-without-extension.json");
+            Assert.Equal(messages.Count(), 1);
+        }
+
+        [Fact]
+        public void LongRunningHasExtensionTrueValidation()
+        {
+            var messages = GetValidationMessagesForRule<LongRunningOperationsWithLongRunningExtension>("long-running-operation-with-extension-false.json");
+            Assert.Equal(messages.Count(), 1);
+        }
     }
 
     #region Positive tests
@@ -788,6 +802,16 @@ namespace OpenAPI.Validator.Tests
         public void ValidResourceModelReadOnlyProperties()
         {
             var messages = GetValidationMessagesForRule<RequiredPropertiesMissingInResourceModel>(Path.Combine("positive", "valid-resource-model-readonly-props.json"));
+            Assert.Empty(messages);
+        }
+
+        /// <summary>
+        /// Verifies extension for long running operation
+        /// </summary>
+        [Fact]
+        public void ValidExtensionForLongRunningOperation()
+        {
+            var messages = GetValidationMessagesForRule<LongRunningOperationsWithLongRunningExtension>(Path.Combine("positive", "long-running-operation-extension.json"));
             Assert.Empty(messages);
         }
 

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/long-running-operation-with-extension-false.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/long-running-operation-with-extension-false.json
@@ -1,0 +1,51 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "Https"
+  ],
+  "basePath": "/",
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "put": {
+        "operationId": "Redis_Create",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "create params",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": false
+      }
+    }
+  },
+  "parameters": {
+  },
+  "definitions": {
+    "Model": {
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/long-running-operation-without-extension.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/long-running-operation-without-extension.json
@@ -1,0 +1,50 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "Https"
+  ],
+  "basePath": "/",
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "put": {
+        "operationId": "Redis_Create",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "create params",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+  },
+  "definitions": {
+    "Model": {
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/positive/long-running-operation-extension.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/positive/long-running-operation-extension.json
@@ -1,0 +1,51 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "Https"
+  ],
+  "basePath": "/",
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "put": {
+        "operationId": "Redis_Create",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "create params",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "parameters": {
+  },
+  "definitions": {
+    "Model": {
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator/Model/Operation.cs
+++ b/src/dotnet/OpenAPI.Validator/Model/Operation.cs
@@ -13,6 +13,7 @@ namespace OpenAPI.Validator.Model
     /// </summary>
     [Rule(typeof(OperationDescriptionOrSummaryRequired))]
     [Rule(typeof(SummaryAndDescriptionMustNotBeSame))]
+    [Rule(typeof(LongRunningOperationsWithLongRunningExtension))]
     public class Operation : SwaggerBase
     {
         private string _description;

--- a/src/dotnet/OpenAPI.Validator/Properties/Resources.Designer.cs
+++ b/src/dotnet/OpenAPI.Validator/Properties/Resources.Designer.cs
@@ -157,7 +157,7 @@ namespace OpenAPI.Validator.Properties
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to This operation returns 202 status code, which indicates a long running operation, please enable &quot;x-ms-long-running-operation..
+        ///   Looks up a localized string similar to The operation &apos;{0}&apos; returns 202 status code, which indicates a long running operation, please enable &quot;x-ms-long-running-operation..
         /// </summary>
         public static string LongRunningOperationsWithLongRunningExtension
         {

--- a/src/dotnet/OpenAPI.Validator/Properties/Resources.Designer.cs
+++ b/src/dotnet/OpenAPI.Validator/Properties/Resources.Designer.cs
@@ -157,6 +157,17 @@ namespace OpenAPI.Validator.Properties
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to This operation returns 202 status code, which indicates a long running operation, please enable &quot;x-ms-long-running-operation..
+        /// </summary>
+        public static string LongRunningOperationsWithLongRunningExtension
+        {
+            get
+            {
+                return ResourceManager.GetString("LongRunningOperationsWithLongRunningExtension", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to A &apos;{0}&apos; operation &apos;{1}&apos; with x-ms-long-running-operation extension must have a valid terminal success status code {2}..
         /// </summary>
         public static string LongRunningResponseNotValid

--- a/src/dotnet/OpenAPI.Validator/Properties/Resources.resx
+++ b/src/dotnet/OpenAPI.Validator/Properties/Resources.resx
@@ -354,4 +354,7 @@
   <data name="UnsupportedMimeTypeForResponseBody" xml:space="preserve">
     <value>The operation '{0}' has a response body in response '{1}', but did not have a supported MIME type ('application/json' or 'application/octet-stream') in its Produces property.</value>
   </data>
+  <data name="LongRunningOperationsWithLongRunningExtension" xml:space="preserve">
+    <value>This operation returns 202 status code, which indicates a long running operation, please enable "x-ms-long-running-operation.</value>
+  </data>
 </root>

--- a/src/dotnet/OpenAPI.Validator/Properties/Resources.resx
+++ b/src/dotnet/OpenAPI.Validator/Properties/Resources.resx
@@ -355,6 +355,6 @@
     <value>The operation '{0}' has a response body in response '{1}', but did not have a supported MIME type ('application/json' or 'application/octet-stream') in its Produces property.</value>
   </data>
   <data name="LongRunningOperationsWithLongRunningExtension" xml:space="preserve">
-    <value>This operation returns 202 status code, which indicates a long running operation, please enable "x-ms-long-running-operation.</value>
+    <value>The operation '{0}' returns 202 status code, which indicates a long running operation, please enable "x-ms-long-running-operation.</value>
   </data>
 </root>

--- a/src/dotnet/OpenAPI.Validator/Validation/LongRunningOperationsWithLongRunningExtension .cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/LongRunningOperationsWithLongRunningExtension .cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using OpenAPI.Validator.Model;
+using OpenAPI.Validator.Properties;
+using OpenAPI.Validator.Validation.Core;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenAPI.Validator.Validation
+{
+    public class LongRunningOperationsWithLongRunningExtension : TypedRule<Operation>
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "R2007";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.LongRunningOperationsWithLongRunningExtension;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Warning;
+
+        /// <summary>
+        /// What kind of open api document type this rule should be applied to
+        /// </summary>
+        public override ServiceDefinitionDocumentType ServiceDefinitionDocumentType => ServiceDefinitionDocumentType.ARM;
+
+        /// <summary>
+        /// What kind of change implementing this rule can cause.
+        /// </summary>
+        public override ValidationChangesImpact ValidationChangesImpact => ValidationChangesImpact.SDKImpactingChanges;
+
+        /// <summary>
+        /// The rule could be violated by a model referenced by many jsons belonging to the same
+        /// composed state, to reduce duplicate messages, run validation rule in composed state
+        /// </summary>
+        public override ServiceDefinitionDocumentState ValidationRuleMergeState => ServiceDefinitionDocumentState.Individual;
+
+        /// <summary>
+        /// Validates if the long running operation has long running extension enabled.
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <param name="context"></param>
+        /// <returns>true if the long running operation has long running extension enabled. false otherwise.</returns>
+        public override IEnumerable<ValidationMessage> GetValidationMessages(Operation operation, RuleContext context)
+        {
+            if (operation.Responses?.Any(response => response.Key.Equals("202")) == true &&
+              operation.Extensions?.Any(extension => extension.Key.Equals("x-ms-long-running-operation") && (bool)extension.Value) == false)
+            {
+                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, new object[0]);
+            }
+        }
+    }
+}

--- a/src/dotnet/OpenAPI.Validator/Validation/LongRunningOperationsWithLongRunningExtension .cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/LongRunningOperationsWithLongRunningExtension .cs
@@ -62,7 +62,7 @@ namespace OpenAPI.Validator.Validation
             if (operation.Responses?.Any(response => response.Key.Equals("202")) == true &&
               operation.Extensions?.Any(extension => extension.Key.Equals("x-ms-long-running-operation") && (bool)extension.Value) == false)
             {
-                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, new object[0]);
+                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, operation.OperationId);
             }
         }
     }


### PR DESCRIPTION
**What does this rule do?**
A Long Running Operation must have "x-ms-long-running-operation" set to true.

**How do you determine if operation is long running?**
An operation with 202 response is identified as long running operation. 

**Sample error message**
"This operation returns 202 status code, which indicates a long running operation, please enable "x-ms-long-running-operation."

This is a duplicate of https://github.com/Azure/autorest/pull/2424 and related to the issue https://github.com/Azure/autorest/issues/1960 

Please review and approve