### PR TITLE
Code changes to fix bug in arm resources properties bag rule

### DIFF
--- a/src/dotnet/OpenAPI.Validator.Tests/OpenAPIModelerValidationTests.cs
+++ b/src/dotnet/OpenAPI.Validator.Tests/OpenAPIModelerValidationTests.cs
@@ -200,6 +200,37 @@ namespace OpenAPI.Validator.Tests
         }
 
         [Fact]
+        public void ArmResourcePropertiesBagMultipleViolationsValidation()
+        {
+            var messages = GetValidationMessagesForRule<ArmResourcePropertiesBag>("arm-resource-properties-bag-multiple-violations.json");
+            Assert.Equal(messages.Count(), 1);
+            Assert.Equal(messages.First().Message.Contains("[name, type]"), true);
+        }
+
+        [Fact]
+        public void ArmResourcePropertiesBagMultipleLevelViolationsValidation()
+        {
+            var messages = GetValidationMessagesForRule<ArmResourcePropertiesBag>("arm-resource-properties-bag-multiple-level-violations.json");
+            Assert.Equal(messages.Count(), 2);
+            Assert.Equal(messages.First().Message.Contains("[name, type]"), true);
+            Assert.Equal(messages.Last().Message.Contains("[location, id]"), true);
+        }
+
+        [Fact]
+        public void ArmResourcePropertiesBagWithReferenceValidation()
+        {
+            var messages = GetValidationMessagesForRule<ArmResourcePropertiesBag>("arm-resource-properties-bag-with-reference.json");
+            Assert.Equal(messages.Count(), 1);
+        }
+
+        [Fact]
+        public void ArmResourcePropertiesBagWithMultipleLevelReferenceValidation()
+        {
+            var messages = GetValidationMessagesForRule<ArmResourcePropertiesBag>("arm-resource-properties-bag-with-multiple-level-reference.json");
+            Assert.Equal(messages.Count(), 1);
+        }
+
+        [Fact]
         public void CollectionObjectsPropertiesNamingValidation()
         {
             var messages = GetValidationMessagesForRule<CollectionObjectPropertiesNaming>("collection-objects-naming.json");

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-multiple-level-violations.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-multiple-level-violations.json
@@ -1,0 +1,187 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft Azure Redis Cache Management API",
+    "description": "Some cool documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}/Res": {
+      "get": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_get",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "redis cache to get",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "patch": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_update",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "tag",
+            "type": "string",
+            "required": true,
+            "description": "tag to update"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource patched",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/operations": {
+      "get": {
+        "summary": "Lists all foo.",
+        "description": "foo",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "name": "limit",
+            "type": "string",
+            "description": "foo"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationsListResult"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TempResource2": {
+      "description": "temporary resource 2",
+      "properties": {
+        "prop1": {
+          "type": "string"
+        },
+        "properties": {
+          "properties": {
+            "location": {
+              "type":  "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        },
+        {
+          "$ref": "#/definitions/TempResource2"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        },
+        "properties": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "some dummy name"
+            },
+            "type": {
+              "type": "string",
+              "description":  "some dummy type"
+            }
+          }
+        }
+      }
+    },
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Operations"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "apiVersion",
+      "in": "path",
+      "description": "API ID.",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-multiple-violations.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-multiple-violations.json
@@ -1,0 +1,166 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft Azure Redis Cache Management API",
+    "description": "Some cool documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}/Res": {
+      "get": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_get",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "redis cache to get",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "patch": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_update",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "tag",
+            "type": "string",
+            "required": true,
+            "description": "tag to update"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource patched",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/operations": {
+      "get": {
+        "summary": "Lists all foo.",
+        "description": "foo",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "name": "limit",
+            "type": "string",
+            "description": "foo"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationsListResult"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        },
+        "properties": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "some dummy name"
+            },
+            "type": {
+              "type": "string",
+              "description":  "some dummy type"
+            }
+          }
+        }
+      }
+    },
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Operations"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "apiVersion",
+      "in": "path",
+      "description": "API ID.",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-with-multiple-level-reference.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-with-multiple-level-reference.json
@@ -1,0 +1,186 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft Azure Redis Cache Management API",
+    "description": "Some cool documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}/Res": {
+      "get": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_get",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "redis cache to get",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "patch": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_update",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "tag",
+            "type": "string",
+            "required": true,
+            "description": "tag to update"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource patched",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/operations": {
+      "get": {
+        "summary": "Lists all foo.",
+        "description": "foo",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "name": "limit",
+            "type": "string",
+            "description": "foo"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationsListResult"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TempResource3": {
+      "description": "temporary resource 3",
+      "properties": {
+        "prop1": {
+          "type": "string"
+        },
+        "properties": {
+          "properties": {
+            "location": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "TempResource2": {
+      "description": "temporary resource 2",
+      "properties": {
+        "prop1": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/TempResource3"
+        }
+      }
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/TempResource2"
+        }
+      }
+    },
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Operations"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "apiVersion",
+      "in": "path",
+      "description": "API ID.",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-with-reference.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/arm-resource-properties-bag-with-reference.json
@@ -1,0 +1,175 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft Azure Redis Cache Management API",
+    "description": "Some cool documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}/Res": {
+      "get": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_get",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "redis cache to get",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "patch": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_update",
+        "description": "gets a Redis cache.",
+        "parameters": [
+          {
+            "name": "tag",
+            "type": "string",
+            "required": true,
+            "description": "tag to update"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the resource patched",
+            "schema": {
+              "$ref": "#/definitions/TempResource"
+            }
+          }
+        }
+      }
+    },
+    "/operations": {
+      "get": {
+        "summary": "Lists all foo.",
+        "description": "foo",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "name": "limit",
+            "type": "string",
+            "description": "foo"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationsListResult"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TempResource2": {
+      "description": "temporary resource 2",
+      "properties": {
+        "prop1": {
+          "type": "string"
+        },
+        "properties": {
+          "properties": {
+            "location": {
+              "type":  "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/TempResource2"
+        }
+      }
+    },
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Operations"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "apiVersion",
+      "in": "path",
+      "description": "API ID.",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator/Validation/ArmResourcePropertiesBag.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/ArmResourcePropertiesBag.cs
@@ -95,7 +95,7 @@ namespace OpenAPI.Validator.Validation
                     else
                     {
                         IEnumerable<string> violatingProperties = resourceModel.Properties["properties"].Properties?.Keys?.Intersect(ArmPropertiesBag);
-                        if (violatingProperties.Any() == true)
+                        if (violatingProperties?.Any() == true)
                         {
                             violations[resourceModelName] = violatingProperties;
                         }

--- a/src/dotnet/OpenAPI.Validator/Validation/ArmResourcePropertiesBag.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/ArmResourcePropertiesBag.cs
@@ -83,28 +83,31 @@ namespace OpenAPI.Validator.Validation
         /// <param name="violations">violations table</param>
         private void CheckModelForViolation(Schema resourceModel, string resourceModelName, Dictionary<string, Schema> definitions, RuleContext context, Dictionary<string, IEnumerable<string>> violations)
         {
-            if (resourceModel.Properties?.ContainsKey("properties") == true)
+            if(resourceModel != null)
             {
-                string referenceName = resourceModel.Properties["properties"].Reference;
-                if (!string.IsNullOrWhiteSpace(referenceName))
+                if (resourceModel.Properties?.ContainsKey("properties") == true)
                 {
-                    CheckModelForViolation(Schema.FindReferencedSchema(referenceName, definitions), Validator.Extensions.StripDefinitionPath(referenceName), definitions, context, violations);
-                }
-                else
-                {
-                    IEnumerable<string> violatingProperties = resourceModel.Properties["properties"].Properties?.Keys?.Intersect(ArmPropertiesBag);
-                    if (violatingProperties?.Any() == true)
+                    string referenceName = resourceModel.Properties["properties"].Reference;
+                    if (!string.IsNullOrWhiteSpace(referenceName))
                     {
-                        violations[resourceModelName] = violatingProperties;
+                        CheckModelForViolation(Schema.FindReferencedSchema(referenceName, definitions), Validator.Extensions.StripDefinitionPath(referenceName), definitions, context, violations);
+                    }
+                    else
+                    {
+                        IEnumerable<string> violatingProperties = resourceModel.Properties["properties"].Properties?.Keys?.Intersect(ArmPropertiesBag);
+                        if (violatingProperties.Any() == true)
+                        {
+                            violations[resourceModelName] = violatingProperties;
+                        }
                     }
                 }
-            }
 
-            if (resourceModel.AllOf != null)
-            {
-                foreach (Schema schema in resourceModel.AllOf)
+                if (resourceModel.AllOf != null)
                 {
-                    CheckModelForViolation(Schema.FindReferencedSchema(schema.Reference, definitions), Validator.Extensions.StripDefinitionPath(schema.Reference), definitions, context, violations);
+                    foreach (Schema schema in resourceModel.AllOf)
+                    {
+                        CheckModelForViolation(Schema.FindReferencedSchema(schema.Reference, definitions), Validator.Extensions.StripDefinitionPath(schema.Reference), definitions, context, violations);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Related to https://github.com/Azure/azure-openapi-validator/issues/36 

This rule has the following issues:
1. The rule ignores the reference values
2. The 'tags' property is misspelled as 'tag'
3. The rule ignores the allOf values

I have covered the missing cases and added possible examples. Please review and approve