### PR TITLE
Returning correct path from PostOperationIdContainsUrlVerb

### DIFF
--- a/src/typescript/azure-openapi-validator/rules/PostOperationIdContainsUrlVerb.ts
+++ b/src/typescript/azure-openapi-validator/rules/PostOperationIdContainsUrlVerb.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
 import { MergeStates, OpenApiTypes, rules } from '../rule';
 export const PostOperationIdContainsUrlVerb: string = "PostOperationIdContainsUrlVerb";
 rules.push({
@@ -20,7 +19,6 @@ rules.push({
     // get the url
     const pathNodes: string[] = (<string>path[path.length - 1]).toLowerCase().split('/');
     const urlVerb: string = pathNodes[pathNodes.length - 1];
-
     // now get hold of the operation id
     const keys = Object.keys(node);
     const postKey = keys.find(key => {

--- a/src/typescript/azure-openapi-validator/rules/PostOperationIdContainsUrlVerb.ts
+++ b/src/typescript/azure-openapi-validator/rules/PostOperationIdContainsUrlVerb.ts
@@ -29,7 +29,7 @@ rules.push({
     // check if we have an operation id without the verb at the end of the url
     // if not, this should be a violation
     if (operationId.toLowerCase().split('_').pop().indexOf(urlVerb) === -1) {
-      yield { message: `OperationId should contain the verb: '${urlVerb}' in:'${operationId}'. Consider updating the operationId`, location: path.concat(postKey).concat(operationId) };
+      yield { message: `OperationId should contain the verb: '${urlVerb}' in:'${operationId}'. Consider updating the operationId`, location: path.concat(postKey).concat('operationId') };
     }
   }
 });

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -2,19 +2,15 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+
+import { suite, test } from 'mocha-typescript';
+import * as assert from "assert";
 import { Message } from '../../jsonrpc/types';
-import { suite, test, slow, timeout, skip, only } from "mocha-typescript";
-import { safeLoad } from "js-yaml";
-import { AutoRestPluginHost } from "../../jsonrpc/plugin-host";
-import { run } from "../../azure-openapi-validator";
-import {
-  assertValidationRuleCount,
-  collectTestMessagesFromValidator
-} from './utilities/tests-helper';
 import { MergeStates, OpenApiTypes } from '../rule';
 import { ControlCharactersAreNotAllowed } from '../rules/ControlCharactersAreNotAllowed';
-import { PostOperationIdContainsUrlVerb } from '../rules/PostOperationIdContainsUrlVerb';
 import { LicenseHeaderMustNotBeSpecified } from '../rules/LicenseHeaderMustNotBeSpecified';
+import { PostOperationIdContainsUrlVerb } from '../rules/PostOperationIdContainsUrlVerb';
+import { assertValidationRuleCount, collectTestMessagesFromValidator } from './utilities/tests-helper';
 
 @suite class IndividualAzureTests {
   @test async "control characters not allowed test"() {
@@ -27,6 +23,7 @@ import { LicenseHeaderMustNotBeSpecified } from '../rules/LicenseHeaderMustNotBe
     const fileName = 'PostOperationIdWithoutUrlVerb.json';
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual);
     assertValidationRuleCount(messages, PostOperationIdContainsUrlVerb, 1);
+	assert(messages[0].Text === "OperationId should contain the verb: 'invoke' in:'simpleManualTrigger_call'. Consider updating the operationId");
   }
   @test async "info section with x-ms-code-generation-settings must not contain a header"() {
     const fileName = 'InfoWithLicenseHeader.json';

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -2,15 +2,20 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
-import { suite, test } from 'mocha-typescript';
-import * as assert from "assert";
 import { Message } from '../../jsonrpc/types';
+import { suite, test, slow, timeout, skip, only } from "mocha-typescript";
+import { safeLoad } from "js-yaml";
+import { AutoRestPluginHost } from "../../jsonrpc/plugin-host";
+import { run } from "../../azure-openapi-validator";
+import {
+  assertValidationRuleCount,
+  collectTestMessagesFromValidator
+} from './utilities/tests-helper';
 import { MergeStates, OpenApiTypes } from '../rule';
 import { ControlCharactersAreNotAllowed } from '../rules/ControlCharactersAreNotAllowed';
-import { LicenseHeaderMustNotBeSpecified } from '../rules/LicenseHeaderMustNotBeSpecified';
 import { PostOperationIdContainsUrlVerb } from '../rules/PostOperationIdContainsUrlVerb';
-import { assertValidationRuleCount, collectTestMessagesFromValidator } from './utilities/tests-helper';
+import { LicenseHeaderMustNotBeSpecified } from '../rules/LicenseHeaderMustNotBeSpecified';
+import * as assert from "assert";
 
 @suite class IndividualAzureTests {
   @test async "control characters not allowed test"() {
@@ -23,7 +28,7 @@ import { assertValidationRuleCount, collectTestMessagesFromValidator } from './u
     const fileName = 'PostOperationIdWithoutUrlVerb.json';
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual);
     assertValidationRuleCount(messages, PostOperationIdContainsUrlVerb, 1);
-	assert(messages[0].Text === "OperationId should contain the verb: 'invoke' in:'simpleManualTrigger_call'. Consider updating the operationId");
+	assert(messages[0].Text === "OperationId should contain the verb: 'invoke' in:'simpleManualTrigger_call'. Consider updating the operationId"); 
   }
   @test async "info section with x-ms-code-generation-settings must not contain a header"() {
     const fileName = 'InfoWithLicenseHeader.json';


### PR DESCRIPTION
Addressing https://github.com/Azure/azure-openapi-validator/issues/101