### PR TITLE
update gulp-dotnet-cli

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,83 +5,86 @@
 
 var path = require('path');
 var gulp = require('gulp');
-var clean = require('gulp-clean');
+var gulpClean = require('gulp-clean');
 var run = require('gulp-run')
 var mocha = require('gulp-mocha');
-var { restore, build, test, pack, publish } = require('gulp-dotnet-cli');
+var { restore, clean, build, test, pack, publish } = require('gulp-dotnet-cli');
 
 // add .bin to PATH
 function getPathVariableName() {
-    // windows calls it's path 'Path' usually, but this is not guaranteed.
-    if (process.platform === 'win32') {
-        for (const key of Object.keys(process.env))
-            if (key.match(/^PATH$/i))
-                return key;
-        return 'Path';
-    }
-    return "PATH";
+  // windows calls it's path 'Path' usually, but this is not guaranteed.
+  if (process.platform === 'win32') {
+    for (const key of Object.keys(process.env))
+      if (key.match(/^PATH$/i))
+        return key;
+    return 'Path';
+  }
+  return "PATH";
 }
 process.env[getPathVariableName()] = path.join(__dirname, "src/dotnet/AutoRest/node_modules/.bin") + path.delimiter + process.env[getPathVariableName()];
 
 // All the typescript tasks
 gulp.task('clean/typescript', function () {
-    console.log('Cleaning build directories...');
-    return gulp.src(['src/typescript/azure-openapi-validator/*.{js,d.ts}', 'src/typescript/jsonrpc/*.{js,d.ts}'], { read: false })
-        .pipe(clean({ force: true }));
+  console.log('Cleaning build directories...');
+  return gulp.src(['src/typescript/azure-openapi-validator/*.{js,d.ts}', 'src/typescript/jsonrpc/*.{js,d.ts}'], { read: false })
+    .pipe(gulpClean({ force: true }));
 });
 
 gulp.task('build/typescript', ['clean/typescript'], function () {
-    console.log('Running the typescript transpiler...');
-    return gulp.src('./src/typescript/').pipe(run('tsc --project tsconfig.json'));
+  console.log('Running the typescript transpiler...');
+  return gulp.src('./src/typescript/').pipe(run('tsc --project tsconfig.json'));
 });
 
 gulp.task('test/typescript', ['build/typescript'], function () {
-    console.log('Running the unit tests...');
-    gulp.src(['src/typescript/azure-openapi-validator/tests/*.js'])
-        .pipe(mocha({
-            timeout: 120000
-        }))
-        .once('error', () => {
-            process.exit(1);
-        });
+  console.log('Running the unit tests...');
+  gulp.src(['src/typescript/azure-openapi-validator/tests/*.js'])
+    .pipe(mocha({
+      timeout: 120000
+    }))
+    .once('error', () => {
+      process.exit(1);
+    });
 });
 
 // All the dotnet tasks
 gulp.task('clean/dotnet', function () {
-    console.log('Cleaning build directories...');
-    return gulp.src(['src/dotnet/**/bin', 'src/dotnet/**/obj'], { read: false })
-        .pipe(clean({ force: true }));
+  console.log('Running dotnet clean...');
+  return gulp.src('src/dotnet/**/*.csproj', { read: false })
+    .pipe(clean());
 });
 
 gulp.task('restore/dotnet', ['clean/dotnet'], function () {
-    console.log('Running dotnet restore...');
-    return gulp.src('src/dotnet/**/*.csproj')
-        .pipe(restore());
+  console.log('Running dotnet restore...');
+  return gulp.src('src/dotnet/**/*.csproj')
+    .pipe(restore());
 });
 
 gulp.task('build/dotnet', ['restore/dotnet'], function () {
-    console.log('Running dotnet build...');
-    return gulp.src('src/dotnet/**/*.csproj')
-        .pipe(build());
+  console.log('Running dotnet build...');
+  return gulp.src('src/dotnet/**/*.csproj')
+    .pipe(build());
 });
 
 gulp.task('test/dotnet', ['build/dotnet'], function () {
-    console.log('Running the dotnet unit tests...');
-    return gulp.src('src/dotnet/OpenAPI.Validator.Tests/OpenAPI.Validator.Tests.csproj')
-        .pipe(test({ verbosity: 'minimal' }));
+  console.log('Running the dotnet unit tests...');
+  return gulp.src('src/dotnet/OpenAPI.Validator.Tests/OpenAPI.Validator.Tests.csproj')
+    .pipe(test({
+      verbosity: 'minimal',
+      noBuild: true
+    }));
 });
 
 // Now the defaults/commons
 gulp.task('build', ['build/dotnet', 'build/typescript'], function () {
-    console.log('Building code...');
+  console.log('Building code...');
 });
 
 gulp.task('clean', ['clean/typescript', 'clean/dotnet'], function () {
-    console.log('Cleaning artifacts...');
+  console.log('Cleaning artifacts...');
 });
 
 gulp.task('test', ['test/dotnet', 'test/typescript'], function () {
-    console.log('Successfully ran the tests...');
+  console.log('Successfully ran the tests...');
 });
 
 gulp.task('dotnet', ['test/dotnet'], function () {
@@ -91,11 +94,16 @@ gulp.task('typescript', ['test/typescript'], function () {
 });
 
 gulp.task('default', ['dotnet', 'typescript'], function () {
-    console.log('Successfully built and tested the repo...');
+  console.log('Successfully built and tested the repo...');
 });
 
 gulp.task('dotnet/pack', ['dotnet', 'typescript'], function () {
-    console.log('Kicking off the dotnet publish task...');
-    return gulp.src('src/dotnet/AutoRest/AutoRest.csproj')
-        .pipe(run('dotnet publish src/dotnet/AutoRest/AutoRest.csproj --configuration release --output bin/netcoreapp2.0'));
+  console.log('Kicking off the dotnet publish task...');
+  return gulp.src('src/dotnet/AutoRest/AutoRest.csproj')
+    .pipe(
+    publish({
+      output: "bin/netcoreapp2.0",
+      configuration: "release"
+    })
+    );
 });

--- a/package.json
+++ b/package.json
@@ -1,28 +1,28 @@
 {
-    "name": "CommonDeps",
-    "version": "0.0.0",
-    "description": "Common dev deps for repo",
-    "readme": "https://github.com/Azure/azure-openapi-validator/readme.md",
-    "devDependencies": {
-        "@types/js-yaml": "^3.5.30",
-        "@types/jsonpath": "^0.1.29",
-        "@types/node": "^7.0.18",
-        "gulp": "3.9.1",
-        "gulp-run": "1.7.1",
-        "gulp-clean": "0.3.2",
-        "gulp-mocha": "4.3.1",
-        "gulp-dotnet-cli": "0.4.0",
-        "mocha": "3.2.0",
-        "mocha-typescript": "1.0.22",
-        "typescript": "2.3.3"
-    },
-    "dependencies": {
-        "fs": "^0.0.1-security",
-        "js-yaml": "^3.8.4",
-        "jsonpath": "^0.2.11",
-        "vscode-jsonrpc": "^3.2.0"
-    },
-    "scripts": {
-        "postinstall": "cd src/dotnet/AutoRest && npm install"
-    }
+  "name": "CommonDeps",
+  "version": "0.0.0",
+  "description": "Common dev deps for repo",
+  "readme": "https://github.com/Azure/azure-openapi-validator/readme.md",
+  "devDependencies": {
+    "@types/js-yaml": "^3.5.30",
+    "@types/jsonpath": "^0.1.29",
+    "@types/node": "^7.0.18",
+    "gulp": "3.9.1",
+    "gulp-run": "1.7.1",
+    "gulp-clean": "0.3.2",
+    "gulp-mocha": "4.3.1",
+    "gulp-dotnet-cli": "1.0.4",
+    "mocha": "3.2.0",
+    "mocha-typescript": "1.0.22",
+    "typescript": "2.3.3"
+  },
+  "dependencies": {
+    "fs": "^0.0.1-security",
+    "js-yaml": "^3.8.4",
+    "jsonpath": "^0.2.11",
+    "vscode-jsonrpc": "^3.2.0"
+  },
+  "scripts": {
+    "postinstall": "cd src/dotnet/AutoRest && npm install"
+  }
 }


### PR DESCRIPTION
* Auto formatting brought to you by the .vscode folder already checked into the project
* Update to gulp-dotnet-cli to 1.0.4
  * No real breaking changes
  * Code quality improved
  * typescript definitions in the package
* Switch from gulp-clean to gulp-dotnet-cli's clean for dotnet build artifacts
* use publish from gulp-dotnet-cli
