### PR TITLE
Revert "Remove XMSExamplesRequired rule and bump version"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## What's New (04/26/2018)	
+	
+### Changed Rule	
+- Changed the linter rule XmsExamplesRequired -- it now has a Category of `Documentation` and an id of `D5001`. Refer [Issue #189](https://github.com/Azure/azure_sdk_ci_tools/issues/189) for further details.
+
 ## What's New (03/14/2018)
 
 ### Resolved issues/Bug fixes

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## What's New (04/26/2018)
-
-### Removed Rule
-- Removed the linter rule XmsExamplesRequired since the rule is related to documentation. Refer [Issue #189](https://github.com/Azure/azure_sdk_ci_tools/issues/189) for further details.
-
 ## What's New (03/14/2018)
 
 ### Resolved issues/Bug fixes

--- a/src/dotnet/AutoRest/package.json
+++ b/src/dotnet/AutoRest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft.azure/classic-openapi-validator",
-    "version": "1.0.11",
+    "version": "1.0.10",
     "description": "The classic OpenAPI validator plugin for AutoRest",
     "scripts": {
         "start": "dotnet ./bin/netcoreapp2.0/AutoRest.dll --server"

--- a/src/dotnet/AutoRest/package.json
+++ b/src/dotnet/AutoRest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft.azure/classic-openapi-validator",
-    "version": "1.0.10",
+    "version": "1.0.12",
     "description": "The classic OpenAPI validator plugin for AutoRest",
     "scripts": {
         "start": "dotnet ./bin/netcoreapp2.0/AutoRest.dll --server"

--- a/src/dotnet/OpenAPI.Validator.Tests/OpenAPIModelerValidationTests.cs
+++ b/src/dotnet/OpenAPI.Validator.Tests/OpenAPIModelerValidationTests.cs
@@ -583,6 +583,13 @@ namespace OpenAPI.Validator.Tests
         }
 
         [Fact]
+        public void XmsExamplesProvidedValidation()
+        {
+            var messages = GetValidationMessagesForRule<XmsExamplesRequired>("xms-examples-absent.json");
+            Assert.Equal(messages.Count(), 2);
+        }
+
+        [Fact]
         public void PutResponseResourceValidationTest()
         {
             var messages = GetValidationMessagesForRule<XmsResourceInPutResponse>("put-response-resource-validation.json");

--- a/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/xms-examples-absent.json
+++ b/src/dotnet/OpenAPI.Validator.Tests/Resource/OpenAPI/Validation/xms-examples-absent.json
@@ -1,0 +1,137 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "basePath": "/",
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "Models_list",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          },
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Models"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-ms-paths": {
+    "/foo?{id}": {
+      "get": {
+        "operationId": "foo_listByID",
+        "summary": "Foo get path",
+        "description": "Foo get operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          },
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Models"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "schemes": [
+          "https"
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    },
+    "id": {
+      "name": "api-id",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api id"
+    }
+  },
+  "definitions": {
+    "Models": {
+      "description": "the models to return",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "description of the value",
+          "items": {
+            "$ref": "#/definitions/Model"
+          }
+        }
+      }
+    },
+    "Model": {
+      "description": "the model returned",
+      "properties": {
+        "prop0": {
+          "description": "some property",
+          "type": "string"
+        }
+      }
+    },
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Operations"
+        }
+      }
+    }
+  }
+}

--- a/src/dotnet/OpenAPI.Validator/Model/ServiceDefinition.cs
+++ b/src/dotnet/OpenAPI.Validator/Model/ServiceDefinition.cs
@@ -83,6 +83,7 @@ namespace OpenAPI.Validator.Model
         [CollectionRule(typeof(BodyPropertiesNamesCamelCase))]
         [Rule(typeof(PutRequestResponseScheme))]
         [Rule(typeof(TrackedResourceListByImmediateParent))]
+        [Rule(typeof(XmsExamplesRequired))]
         [Rule(typeof(LROStatusCodesReturnTypeSchema))]
         public Dictionary<string, Dictionary<string, Operation>> Paths { get; set; }
 
@@ -94,6 +95,7 @@ namespace OpenAPI.Validator.Model
         [Rule(typeof(CollectionObjectPropertiesNaming))]
         [CollectionRule(typeof(XmsPathsMustOverloadPaths))]
         [CollectionRule(typeof(BodyPropertiesNamesCamelCase))]
+        [Rule(typeof(XmsExamplesRequired))]
         public Dictionary<string, Dictionary<string, Operation>> CustomPaths { get; set; }
 
         /// <summary>

--- a/src/dotnet/OpenAPI.Validator/Validation/Core/ValidationCategory.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/Core/ValidationCategory.cs
@@ -11,6 +11,7 @@ namespace OpenAPI.Validator.Validation.Core
         None            = 0,
         RPCViolation    = 1 << 0,
         OneAPIViolation = 1 << 1,
-        SDKViolation    = 1 << 2
+        SDKViolation    = 1 << 2,
+        Documentation   = 1 << 3 
     }
 }

--- a/src/dotnet/OpenAPI.Validator/Validation/XmsExamplesRequired.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/XmsExamplesRequired.cs
@@ -18,7 +18,7 @@ namespace OpenAPI.Validator.Validation
         /// <summary>
         /// Id of the Rule.
         /// </summary>
-        public override string Id => "R2022";
+        public override string Id => "D5001";
 
         private string OperationIdMessageSuffix => " Operation: '{0}'";
 

--- a/src/dotnet/OpenAPI.Validator/Validation/XmsExamplesRequired.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/XmsExamplesRequired.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using AutoRest.Core.Logging;
+using OpenAPI.Validator.Validation.Core;
+using OpenAPI.Validator.Model;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+
+namespace OpenAPI.Validator.Validation
+{
+    public class XmsExamplesRequired : TypedRule<Dictionary<string, Dictionary<string, Operation>>>
+    {
+        // the maximum number of non-xms-examples operations to allow.
+        private const int magicNumber = 10;
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "R2022";
+
+        private string OperationIdMessageSuffix => " Operation: '{0}'";
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations.{0}";
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Error;
+
+        /// <summary>
+        /// What kind of open api document type this rule should be applied to
+        /// </summary>
+        public override ServiceDefinitionDocumentType ServiceDefinitionDocumentType => ServiceDefinitionDocumentType.ARM | ServiceDefinitionDocumentType.DataPlane;
+
+        /// <summary>
+        /// The rule runs on each operation in isolation irrespective of the state and can be run in individual state
+        /// </summary>
+        public override ServiceDefinitionDocumentState ValidationRuleMergeState => ServiceDefinitionDocumentState.Individual;
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        private bool IsValidJson(string jsonString)
+        {
+            try
+            {
+                var jObject = JObject.Parse(jsonString);
+                if (jObject == null)
+                {
+                    return false;
+                }
+            }
+            catch (System.Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Validates whether operation has corresponding x-ms-examples
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns>ValidationMessage</returns>
+        /// (Dictionary<string, Dictionary<string, Operation>> entity, RuleContext context)
+        public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Dictionary<string, Operation>> paths, RuleContext context)
+        {
+            // find all operations that do not have the x-ms-examples extension or those which have x-ms-examples extension as empty
+            // but ignore operations_list
+            var violatingOps = paths.SelectMany(pathObj => pathObj.Value.Where(opPair
+                                                            => (opPair.Value.Extensions?.ContainsKey("x-ms-examples") != true
+                                                               || string.IsNullOrWhiteSpace(opPair.Value.Extensions["x-ms-examples"].ToString())
+                                                               || !IsValidJson(opPair.Value.Extensions["x-ms-examples"].ToString()))
+                                                               && !opPair.Value.OperationId?.ToLower().Equals("operations_list") == true));
+
+
+
+            // if number of violations exceeds magicNumber, simply aggregate the message
+            if (violatingOps.Count() > magicNumber)
+            {
+                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, string.Empty);
+            }
+            else
+            {
+                foreach (var violatingOp in violatingOps)
+                {
+                    var violatingPath = paths.First(pathObj => pathObj.Value.Values.Select(op => op.OperationId).Contains(violatingOp.Value.OperationId)).Key;
+                    yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty(violatingPath).AppendProperty(violatingOp.Key)), this, string.Format(OperationIdMessageSuffix, violatingOp.Value.OperationId));
+                }
+            }
+        }
+    }
+}

--- a/src/dotnet/OpenAPI.Validator/Validation/XmsExamplesRequired.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/XmsExamplesRequired.cs
@@ -48,7 +48,7 @@ namespace OpenAPI.Validator.Validation
         /// <summary>
         /// Violation category of the Rule.
         /// </summary>
-        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+        public override ValidationCategory ValidationCategory => ValidationCategory.Documentation;
 
         private bool IsValidJson(string jsonString)
         {


### PR DESCRIPTION
Reverts Azure/azure-openapi-validator#159

Rather than remove the rule entirely, we're going to change the category to `Documentation`