### PR TITLE
[RPaaS] PUT async linter rule 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## What's New (08/27/2020)
+
+### New validation rules
+
+- New validation rule for validating long running operations for RPs hosted in RP-as-a-Service platform. Documentation [link](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/openapi-authoring-automated-guidelines.md#R4023)
+
 ## What's New (07/30/2020)
 
 ### New validation Rule

--- a/src/dotnet/OpenAPI.Validator/Validation/Core/ValidationCategory.cs
+++ b/src/dotnet/OpenAPI.Validator/Validation/Core/ValidationCategory.cs
@@ -12,6 +12,7 @@ namespace OpenAPI.Validator.Validation.Core
         ARMViolation = 1 << 0,
         OneAPIViolation = 1 << 1,
         SDKViolation = 1 << 2,
-        Documentation = 1 << 3
+        Documentation = 1 << 3,
+        RPaaSViolation = 1 << 4
     }
 }

--- a/src/typescript/azure-openapi-validator/index.ts
+++ b/src/typescript/azure-openapi-validator/index.ts
@@ -34,6 +34,7 @@ require("./rules/NestedResourcesMustHaveListOperation")
 require("./rules/TopLevelResourcesListByResourceGroup")
 require("./rules/TopLevelResourcesListBySubscription")
 require("./rules/OperationsApiResponseSchema")
+require("./rules/Rpaas_CreateOperationAsyncResponseValidation")
 
 export async function run(
   document: string,

--- a/src/typescript/azure-openapi-validator/rule.ts
+++ b/src/typescript/azure-openapi-validator/rule.ts
@@ -24,7 +24,7 @@ export interface ValidationMessage {
 export interface Rule {
   readonly id: string // see Rxxx/Sxxx codes on https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/openapi-authoring-automated-guidelines.md
   readonly name: string // see same website as above
-  readonly category: "ARMViolation" | "OneAPIViolation" | "SDKViolation"
+  readonly category: "ARMViolation" | "OneAPIViolation" | "SDKViolation" | "RPaaSViolation"
   readonly severity: "error" | "warning"
 
   readonly mergeState: MergeStates

--- a/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
@@ -6,7 +6,7 @@ import { MergeStates, OpenApiTypes, rules } from "../rule"
 export const Rpaas_CreateOperationAsyncResponseValidation: string = "Rpaas_CreateOperationAsyncResponseValidation"
 
 rules.push({
-  id: "R4014",
+  id: "R4023",
   name: Rpaas_CreateOperationAsyncResponseValidation,
   severity: "error",
   category: "RPaaSViolation",

--- a/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
@@ -33,7 +33,7 @@ rules.push({
         }
       }
 
-      if (!node.responses["x-ms-long-running-operation"] || node.responses["x-ms-long-running-operation"] != true) {
+      if (!node.responses["x-ms-long-running-operation"] || node.responses["x-ms-long-running-operation"] !== true) {
         yield {
           message: `[RPaaS] An async PUT operation must set '"x-ms-long-running-operation" : true''.`,
           location: path

--- a/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
@@ -6,12 +6,12 @@ import { MergeStates, OpenApiTypes, rules } from "../rule"
 export const Rpaas_CreateOperationAsyncResponseValidation: string = "Rpaas_CreateOperationAsyncResponseValidation"
 
 rules.push({
-  id: "R4011",
+  id: "R4014",
   name: Rpaas_CreateOperationAsyncResponseValidation,
   severity: "error",
-  category: "ARMViolation",
+  category: "RPaaSViolation",
   mergeState: MergeStates.individual,
-  openapiType: OpenApiTypes.arm,
+  openapiType: OpenApiTypes.arm | OpenApiTypes.rpass,
   appliesTo_JsonQuery: "$.paths.*.put",
   *run(doc, node, path) {
     if (node.responses["202"]) {

--- a/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { MergeStates, OpenApiTypes, rules } from "../rule"
+export const Rpaas_CreateOperationAsyncResponseValidation: string = "Rpaas_CreateOperationAsyncResponseValidation"
+
+rules.push({
+  id: "R4011",
+  name: Rpaas_CreateOperationAsyncResponseValidation,
+  severity: "error",
+  category: "ARMViolation",
+  mergeState: MergeStates.individual,
+  openapiType: OpenApiTypes.arm,
+  appliesTo_JsonQuery: "$.paths.*.put",
+  *run(doc, node, path) {
+    if (node.responses["202"]) {
+      yield {
+        message: `[RPaaS] Only 201 is the supported response code for PUT async response.`,
+        location: path
+      }
+    }
+
+    const isAsyncOperation = node.responses["201"]
+      || (node["x-ms-long-running-operation"] && node["x-ms-long-running-operation"] == true)
+      || node["x-ms-long-running-operation-options"];
+
+    if (isAsyncOperation) {
+      if (!node.responses["201"]) {
+        yield {
+          message: `[RPaaS] An async PUT operation must return 201.`,
+          location: path
+        }
+      }
+
+      if (!node.responses["x-ms-long-running-operation"] || node.responses["x-ms-long-running-operation"] != true) {
+        yield {
+          message: `[RPaaS] An async PUT operation must set '"x-ms-long-running-operation" : true''.`,
+          location: path
+        }
+      }
+
+      if (!node.responses["x-ms-long-running-operation-options"]) {
+        yield {
+          message: `[RPaaS] An async PUT operation must set long running operation options 'x-ms-long-running-operation-options'`,
+          location: path
+        }
+      }
+
+      if (node.responses["x-ms-long-running-operation-options"] &&
+        (!node.responses["x-ms-long-running-operation-options"]["final-state-via"]
+        || node.responses["x-ms-long-running-operation-options"]["final-state-via"] != "azure-async-operation")) {
+        yield {
+          message: `[RPaaS] An async PUT operation is tracked via Azure-AsyncOperation header. Set 'final-state-via' property to 'azure-async-operation' on 'x-ms-long-running-operation-options'`,
+          location: path
+        }
+      }
+    }
+  }
+})

--- a/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
@@ -11,7 +11,7 @@ rules.push({
   severity: "error",
   category: "RPaaSViolation",
   mergeState: MergeStates.individual,
-  openapiType: OpenApiTypes.arm | OpenApiTypes.rpass,
+  openapiType: OpenApiTypes.rpass,
   appliesTo_JsonQuery: "$.paths.*.put",
   *run(doc, node, path) {
     if (node.responses["202"]) {

--- a/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/Rpaas_CreateOperationAsyncResponseValidation.ts
@@ -17,7 +17,7 @@ rules.push({
     if (node.responses["202"]) {
       yield {
         message: `[RPaaS] Only 201 is the supported response code for PUT async response.`,
-        location: path
+        location: path.concat(["responses", "202"])
       }
     }
 
@@ -29,27 +29,27 @@ rules.push({
       if (!node.responses["201"]) {
         yield {
           message: `[RPaaS] An async PUT operation must return 201.`,
-          location: path
+          location: path.concat(["responses"])
         }
       }
 
-      if (!node.responses["x-ms-long-running-operation"] || node.responses["x-ms-long-running-operation"] !== true) {
+      if (!node["x-ms-long-running-operation"] || node["x-ms-long-running-operation"] !== true) {
         yield {
           message: `[RPaaS] An async PUT operation must set '"x-ms-long-running-operation" : true''.`,
           location: path
         }
       }
 
-      if (!node.responses["x-ms-long-running-operation-options"]) {
+      if (!node["x-ms-long-running-operation-options"]) {
         yield {
           message: `[RPaaS] An async PUT operation must set long running operation options 'x-ms-long-running-operation-options'`,
           location: path
         }
       }
 
-      if (node.responses["x-ms-long-running-operation-options"] &&
-        (!node.responses["x-ms-long-running-operation-options"]["final-state-via"]
-        || node.responses["x-ms-long-running-operation-options"]["final-state-via"] != "azure-async-operation")) {
+      if (node["x-ms-long-running-operation-options"] &&
+        (!node["x-ms-long-running-operation-options"]["final-state-via"]
+        || node["x-ms-long-running-operation-options"]["final-state-via"] != "azure-async-operation")) {
         yield {
           message: `[RPaaS] An async PUT operation is tracked via Azure-AsyncOperation header. Set 'final-state-via' property to 'azure-async-operation' on 'x-ms-long-running-operation-options'`,
           location: path

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -170,4 +170,11 @@ class IndividualAzureTests {
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpass, MergeStates.individual)
     assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 2)
   }
+
+  // Valid 201 response for RPaaS
+  @test public async "Raas Put async operation is defined correctly"() {
+    const fileName = "RpaasValidPutAsyncOperationResponse.json"
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpass, MergeStates.individual)
+    assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 0)
+  }
 }

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -26,6 +26,7 @@ import { XmsPageableMustHaveCorrespondingResponse } from "../rules/XmsPageableMu
 import { PathResourceProviderNamePascalCase } from "./../rules/PathResourceProviderNamePascalCase"
 import { PathResourceTypeNameCamelCase } from "./../rules/PathResourceTypeNameCamelCase"
 import { assertValidationRuleCount, collectTestMessagesFromValidator } from "./utilities/tests-helper"
+import { Rpaas_CreateOperationAsyncResponseValidation } from "../rules/Rpaas_CreateOperationAsyncResponseValidation"
 @suite
 class IndividualAzureTests {
   
@@ -145,5 +146,28 @@ class IndividualAzureTests {
     const fileName = "PageableOperationWithNullNextLink.json"
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
     assertValidationRuleCount(messages, XmsPageableMustHaveCorrespondingResponse, 0)
+  }
+
+  // Failure #1 : RPaaS async response supports 201 only. 202 is not supported.
+  @test public async "Raas Put async operation doesn't support 202"() {
+    const fileName = "RpaasPutAsyncOperationResponseCodeValidation.json"
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
+    assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 1)
+  }
+
+  // Failure #1 : 'x-ms-long-running-operation' is missing
+  // Failure #2: 'x-ms-long-running-operation-options' is missing
+  @test public async "Raas Put async operation missing x-ms* async extensions"() {
+    const fileName = "RpaasPutAsyncOperationResponseMsCustomExtensionsMissing.json"
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
+    assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 2)
+  }
+
+  // Failure #1 : 'x-ms-long-running-operation' must be true as operation supports 201 (implies async)
+  // Failure #2: 'final-state-via' must be set to 'azure-async-operation'
+  @test public async "Raas Put async operation is tracked using Auzre-AsyncOperation header"() {
+    const fileName = "RpaasPutAsyncOperationResponseFinalStateViaAzureAsync.json"
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
+    assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 2)
   }
 }

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -151,7 +151,7 @@ class IndividualAzureTests {
   // Failure #1 : RPaaS async response supports 201 only. 202 is not supported.
   @test public async "Raas Put async operation doesn't support 202"() {
     const fileName = "RpaasPutAsyncOperationResponseCodeValidation.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpass, MergeStates.individual)
     assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 1)
   }
 
@@ -159,7 +159,7 @@ class IndividualAzureTests {
   // Failure #2: 'x-ms-long-running-operation-options' is missing
   @test public async "Raas Put async operation missing x-ms* async extensions"() {
     const fileName = "RpaasPutAsyncOperationResponseMsCustomExtensionsMissing.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpass, MergeStates.individual)
     assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 2)
   }
 
@@ -167,7 +167,7 @@ class IndividualAzureTests {
   // Failure #2: 'final-state-via' must be set to 'azure-async-operation'
   @test public async "Raas Put async operation is tracked using Auzre-AsyncOperation header"() {
     const fileName = "RpaasPutAsyncOperationResponseFinalStateViaAzureAsync.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpass, MergeStates.individual)
     assertValidationRuleCount(messages, Rpaas_CreateOperationAsyncResponseValidation, 2)
   }
 }

--- a/src/typescript/azure-openapi-validator/tests/resources/RpaasPutAsyncOperationResponseCodeValidation.json
+++ b/src/typescript/azure-openapi-validator/tests/resources/RpaasPutAsyncOperationResponseCodeValidation.json
@@ -1,0 +1,53 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Network interfaces have unallowed types",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}": {
+      "put": {
+        "operationId": "",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "responses": {
+          "202": {
+            "description": "202 is not supported"
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        },
+        "x-ms-long-running-operation": false
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/typescript/azure-openapi-validator/tests/resources/RpaasPutAsyncOperationResponseFinalStateViaAzureAsync.json
+++ b/src/typescript/azure-openapi-validator/tests/resources/RpaasPutAsyncOperationResponseFinalStateViaAzureAsync.json
@@ -1,0 +1,56 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Network interfaces have unallowed types",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}": {
+      "put": {
+        "operationId": "",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "default": {
+            "description": "Unexpected error"
+          },
+          "x-ms-long-running-operation": false,
+          "x-ms-long-running-operation-options": {
+            "final-state-via": "location"
+          }
+        }        
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/typescript/azure-openapi-validator/tests/resources/RpaasPutAsyncOperationResponseMsCustomExtensionsMissing.json
+++ b/src/typescript/azure-openapi-validator/tests/resources/RpaasPutAsyncOperationResponseMsCustomExtensionsMissing.json
@@ -1,0 +1,52 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Network interfaces have unallowed types",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}": {
+      "put": {
+        "operationId": "",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }        
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/typescript/azure-openapi-validator/tests/resources/RpaasValidPutAsyncOperationResponse.json
+++ b/src/typescript/azure-openapi-validator/tests/resources/RpaasValidPutAsyncOperationResponse.json
@@ -22,9 +22,9 @@
         "operationId": "",
         "summary": "Foo path",
         "description": "Foo operation",
-        "x-ms-long-running-operation": false,
+        "x-ms-long-running-operation": true,
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "azure-async-operation"
         },
         "responses": {
           "201": {

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -25,15 +25,12 @@ async function main() {
       try {
         const openapiDefinitionDocument = await initiator.ReadFile(file)
         const openapiDefinitionObject = safeLoad(openapiDefinitionDocument)
-        const openApiTypes = subType != undefined
-          ? OpenApiTypes[openapiType] | OpenApiTypes[subType]
-          : OpenApiTypes[openapiType];
 
         await run(
           file,
           openapiDefinitionObject,
           initiator.Message.bind(initiator),
-          openApiTypes,
+          subType ? OpenApiTypes[subType] : OpenApiTypes[openapiType],
           MergeStates[mergeState]
         )
       } catch (e) {

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -25,11 +25,15 @@ async function main() {
       try {
         const openapiDefinitionDocument = await initiator.ReadFile(file)
         const openapiDefinitionObject = safeLoad(openapiDefinitionDocument)
+        const openApiTypes = subType != undefined
+          ? OpenApiTypes[openapiType] | OpenApiTypes[subType]
+          : OpenApiTypes[openapiType];
+
         await run(
           file,
           openapiDefinitionObject,
           initiator.Message.bind(initiator),
-          subType ? OpenApiTypes[subType] : OpenApiTypes[openapiType],
+          openApiTypes,
           MergeStates[mergeState]
         )
       } catch (e) {

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -25,7 +25,6 @@ async function main() {
       try {
         const openapiDefinitionDocument = await initiator.ReadFile(file)
         const openapiDefinitionObject = safeLoad(openapiDefinitionDocument)
-
         await run(
           file,
           openapiDefinitionObject,

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft.azure/openapi-validator",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Azure OpenAPI Validator",
     "main": "src/index.js",
     "scripts": {


### PR DESCRIPTION
Added linter rule for async PUT operations under RPaaS.
This PR need to wait until openapi-subtype:rpaas is available.