### PR TITLE
Fix R4011 (DeleteOperationResponses) to accept either a 200 or 204 response

### DIFF
--- a/src/typescript/azure-openapi-validator/rules/DeleteOperationResponses.ts
+++ b/src/typescript/azure-openapi-validator/rules/DeleteOperationResponses.ts
@@ -14,7 +14,7 @@ rules.push({
   openapiType: OpenApiTypes.arm,
   appliesTo_JsonQuery: "$.paths.*.delete.responses",
   *run(doc, node, path) {
-    if (!node["200"] || !node["204"] || !Object.keys(node["200"]) || !Object.keys(node["204"])) {
+    if (!(node["200"] && Object.keys(node["200"])) && !(node["204"] && Object.keys(node["204"]))) {
       yield {
         message: `The delete operation is defined without a 200 or 204 error response implementation,please add it.'`,
         location: path


### PR DESCRIPTION
Existing rule implementation requires `DELETE` endpoints to include both a 200 and a 204 response.