### PR TITLE
change async delete response validation 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## What's New (03/24/2022)
+
+### Changed Rule
+- deleteOperationResponse - For LRO delete, 200 is no longer required.
+
 ## What's New (02/07/2022)
 
 ### Changed Rule

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 
 ### Changed Rule
 - deleteOperationResponse - For LRO delete, 200 is no longer required.
+- validFormats - Support 'arm-id' format. 
 
 ## What's New (02/07/2022)
 

--- a/src/dotnet/AutoRest.Core/Model/KnownFormat.cs
+++ b/src/dotnet/AutoRest.Core/Model/KnownFormat.cs
@@ -38,6 +38,7 @@ namespace AutoRest.Core.Model
         ipv6,
         regex,
         json_pointer,
-        relative_json_pointer
+        relative_json_pointer,
+        arm_id
     }
 }

--- a/src/dotnet/AutoRest/package.json
+++ b/src/dotnet/AutoRest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/classic-openapi-validator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The classic OpenAPI validator plugin for AutoRest",
   "scripts": {
     "start": "dotnet ./bin/netcoreapp2.0/AutoRest.dll --server"

--- a/src/dotnet/AutoRest/package.json
+++ b/src/dotnet/AutoRest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/classic-openapi-validator",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "The classic OpenAPI validator plugin for AutoRest",
   "scripts": {
     "start": "dotnet ./bin/netcoreapp2.0/AutoRest.dll --server"

--- a/src/typescript/azure-openapi-validator/rules/DeleteOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/DeleteOperationAsyncResponseValidation.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { MergeStates, OpenApiTypes, rules } from "../rule"
-export const Rpaas_DeleteOperationAsyncResponseValidation: string = "Rpaas_DeleteOperationAsyncResponseValidation"
+export const DeleteOperationAsyncResponseValidation: string = "DeleteOperationAsyncResponseValidation"
 
 rules.push({
   id: "R4025",
-  name: Rpaas_DeleteOperationAsyncResponseValidation,
+  name: DeleteOperationAsyncResponseValidation,
   severity: "error",
   category: "RPaaSViolation",
   mergeState: MergeStates.individual,
@@ -16,7 +16,7 @@ rules.push({
   *run(doc, node, path) {
     if (node.responses["201"]) {
       yield {
-        message: `[RPaaS] Only 202 is the supported response code for DELETE async response.`,
+        message: `Only 202 is the supported response code for DELETE async response.`,
         location: path.concat(["responses", "201"])
       }
     }
@@ -29,21 +29,21 @@ rules.push({
     if (isAsyncOperation) {
       if (!node.responses["202"]) {
         yield {
-          message: `[RPaaS] An async DELETE operation must return 202.`,
+          message: `An async DELETE operation must return 202.`,
           location: path.concat(["responses"])
         }
       }
 
       if (!node["x-ms-long-running-operation"] || node["x-ms-long-running-operation"] !== true) {
         yield {
-          message: `[RPaaS] An async DELETE operation must set '"x-ms-long-running-operation" : true''.`,
+          message: `An async DELETE operation must set '"x-ms-long-running-operation" : true''.`,
           location: path
         }
       }
 
       if (!node["x-ms-long-running-operation-options"]) {
         yield {
-          message: `[RPaaS] An async DELETE operation must set long running operation options 'x-ms-long-running-operation-options'`,
+          message: `An async DELETE operation must set long running operation options 'x-ms-long-running-operation-options'`,
           location: path
         }
       }
@@ -54,7 +54,7 @@ rules.push({
           node["x-ms-long-running-operation-options"]["final-state-via"] != "location")
       ) {
         yield {
-          message: `[RPaaS] An async DELETE operation is tracked via Azure-AsyncOperation header. Set 'final-state-via' property to 'location' on 'x-ms-long-running-operation-options'`,
+          message: `An async DELETE operation is tracked via Azure-AsyncOperation header. Set 'final-state-via' property to 'location' on 'x-ms-long-running-operation-options'`,
           location: path
         }
       }

--- a/src/typescript/azure-openapi-validator/rules/DeleteOperationAsyncResponseValidation.ts
+++ b/src/typescript/azure-openapi-validator/rules/DeleteOperationAsyncResponseValidation.ts
@@ -11,7 +11,7 @@ rules.push({
   severity: "error",
   category: "RPaaSViolation",
   mergeState: MergeStates.individual,
-  openapiType: OpenApiTypes.rpaas,
+  openapiType: OpenApiTypes.arm,
   appliesTo_JsonQuery: "$.paths.*.delete",
   *run(doc, node, path) {
     if (node.responses["201"]) {

--- a/src/typescript/azure-openapi-validator/rules/DeleteOperationResponses.ts
+++ b/src/typescript/azure-openapi-validator/rules/DeleteOperationResponses.ts
@@ -14,6 +14,11 @@ rules.push({
   openapiType: OpenApiTypes.arm,
   appliesTo_JsonQuery: "$.paths.*.delete.responses",
   *run(doc, node, path) {
+    // async delete is not in the scope
+    if (node["202"] || node["x-ms-long-running-operation"]) {
+      return
+    }
+
     if (!node["200"] || !node["204"] || !Object.keys(node["200"]) || !Object.keys(node["204"])) {
       yield {
         message: `The delete operation is defined without a 200 or 204 error response implementation,please add it.'`,

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -27,7 +27,7 @@ import { XmsPageableMustHaveCorrespondingResponse } from "../rules/XmsPageableMu
 import { PathResourceProviderNamePascalCase } from "./../rules/PathResourceProviderNamePascalCase"
 import { PathResourceTypeNameCamelCase } from "./../rules/PathResourceTypeNameCamelCase"
 import { assertValidationRuleCount, collectTestMessagesFromValidator } from "./utilities/tests-helper"
-import { Rpaas_DeleteOperationAsyncResponseValidation } from "../rules/Rpaas_DeleteOperationAsyncResponseValidation"
+import { DeleteOperationAsyncResponseValidation } from "../rules/DeleteOperationAsyncResponseValidation"
 import { Rpaas_PostOperationAsyncResponseValidation } from "../rules/Rpaas_PostOperationAsyncResponseValidation"
 import { Rpaas_ResourceProvisioningState } from "../rules/Rpaas_ResourceProvisioningState"
 import { MissingXmsErrorResponse } from "../rules/MissingXmsErrorResponse"
@@ -201,34 +201,34 @@ class IndividualAzureTests {
     assertValidationRuleCount(messages, PreviewVersionOverOneYear, 1)
   }
 
-  // Failure #1 : RPaaS DELETE async response supports 202 only. 201 is not supported.
-  @test public async "Raas DELETE async operation doesn't support 201"() {
+  // Failure #1 : DELETE async response supports 202 only. 201 is not supported.
+  @test public async "DELETE async operation doesn't support 201"() {
     const fileName = "RpaasDeleteAsyncOperationResponseCodeValidation.json"
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
-    assertValidationRuleCount(messages, Rpaas_DeleteOperationAsyncResponseValidation, 1)
+    assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 1)
   }
 
   // Failure #1 : 'x-ms-long-running-operation' is missing
   // Failure #2: 'x-ms-long-running-operation-options' is missing
-  @test public async "Raas DELETE async operation missing x-ms* async extensions"() {
+  @test public async "DELETE async operation missing x-ms* async extensions"() {
     const fileName = "RpaasDeleteAsyncOperationResponseMsCustomExtensionsMissing.json"
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
-    assertValidationRuleCount(messages, Rpaas_DeleteOperationAsyncResponseValidation, 2)
+    assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 2)
   }
 
   // Failure #1 : 'x-ms-long-running-operation' must be true as operation supports 202 (implies async)
   // Failure #2: 'final-state-via' must be set to 'azure-async-operation'
-  @test public async "Raas DELETE async operation is tracked using Auzre-AsyncOperation header"() {
+  @test public async "DELETE async operation is tracked using Auzre-AsyncOperation header"() {
     const fileName = "RpaasDeleteAsyncOperationResponseFinalStateViaLocation.json"
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
-    assertValidationRuleCount(messages, Rpaas_DeleteOperationAsyncResponseValidation, 2)
+    assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 2)
   }
 
   // Valid 202 response for DELETE operation in RPaaS
   @test public async "Raas DELETE async operation is defined correctly"() {
     const fileName = "RpaasValidDeleteAsyncOperationResponse.json"
     const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
-    assertValidationRuleCount(messages, Rpaas_DeleteOperationAsyncResponseValidation, 0)
+    assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 0)
   }
 
   // Failure #1 : RPaaS POST async response supports 202 only. 201 is not supported.

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -204,7 +204,7 @@ class IndividualAzureTests {
   // Failure #1 : DELETE async response supports 202 only. 201 is not supported.
   @test public async "DELETE async operation doesn't support 201"() {
     const fileName = "RpaasDeleteAsyncOperationResponseCodeValidation.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
     assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 1)
   }
 
@@ -212,7 +212,7 @@ class IndividualAzureTests {
   // Failure #2: 'x-ms-long-running-operation-options' is missing
   @test public async "DELETE async operation missing x-ms* async extensions"() {
     const fileName = "RpaasDeleteAsyncOperationResponseMsCustomExtensionsMissing.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
     assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 2)
   }
 
@@ -227,7 +227,7 @@ class IndividualAzureTests {
   // Valid 202 response for DELETE operation in RPaaS
   @test public async "Raas DELETE async operation is defined correctly"() {
     const fileName = "RpaasValidDeleteAsyncOperationResponse.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
     assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 0)
   }
 

--- a/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
+++ b/src/typescript/azure-openapi-validator/tests/individual-azure-tests.ts
@@ -220,7 +220,7 @@ class IndividualAzureTests {
   // Failure #2: 'final-state-via' must be set to 'azure-async-operation'
   @test public async "DELETE async operation is tracked using Auzre-AsyncOperation header"() {
     const fileName = "RpaasDeleteAsyncOperationResponseFinalStateViaLocation.json"
-    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.rpaas, MergeStates.individual)
+    const messages: Message[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, MergeStates.individual)
     assertValidationRuleCount(messages, DeleteOperationAsyncResponseValidation, 2)
   }
 

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Azure OpenAPI Validator",
   "main": "src/index.js",
   "scripts": {

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Azure OpenAPI Validator",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
1 Rule deleteOperationResponse  does not apply to async delelte
2 change Rpaas_DeleteOperationAsyncResponseValidation to apply to all ARM spec
3 fix https://github.com/Azure/azure-openapi-validator/issues/265