### PR TITLE
Add doc on how to use ruleset from Spectral

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,14 @@ rush test
 Please refer to https://meta.stoplight.io/docs/spectral/ZG9jOjI1MTg5-custom-rulesets firstly.
 and follow below steps to add a rule for azure rest api specs.
 
-- add a custom function in 'packages\rulesets\spectral\functions'
-- add a rule config to the proper ruleset configuaration , current we have 3 ruleset configurations:
-  1. az-common.ts : for rule that apply to all azure spec.
+- add a rule config to the proper ruleset configuaration in packages\rulesets\src\spectral.
+  Currently we have 3 ruleset configurations:
+  1. az-common.ts : for rule that apply to all Azure spec.
   1. az-arm.ts: for rules that only apply to ARM spec.
   1. az-dataplane.ts: for rules that only apply to dataplane spec.
+- if needed, add a custom function in 'packages\rulesets\src\spectral\functions'
 
-- add a test case, usually one custom function should have one test, the corresponding testing files is in 'packages\rulesets\spectral\test'
+- add a test case, usually every rule should have one test, the corresponding testing files is in 'packages\rulesets\src\spectral\test'
 
 - add a doc for the rule in 'docs', the rule doc file name is following kebab-case, contains following content:
 
@@ -68,9 +69,9 @@ and follow below steps to add a rule for azure rest api specs.
 
 ### Native rule
 
-Since the spectral rule can only process one swagger in its rule fucntion, the native ruleset is for complicated rules which need to visit multiple swaggers. For example, if you want to have a rule to ensure two swaggers that does not have duplicated model.
+Since the spectral rule can only process one swagger in its rule function, the native ruleset is for complicated rules which need to visit multiple swaggers. For example, if you want to have a rule to ensure two swaggers that does not have duplicated model.
 
-Differetiating with spectral rule,  there is a swagger inventory (see below defintions) will be peresent in the rule context to visit other swaggers different with current one.
+Differentiating with spectral rule, there is a swagger inventory (see below definitions) will be present in the rule context to visit other swaggers different with current one.
 
 ``` ts
 export interface ISwaggerInventory {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,54 @@ or
 autorest --v3 --azure-validator --input-file=<path-to-swagger>
 ```
 
+## How to use the Spectral ruleset
+
+### Dependencies
+
+The Spectral ruleset requires Node version 14 or later.
+
+### Install Spectral
+
+`npm i @stoplight/spectral-cli -g`
+
+### Usage
+
+Azure-openapi-validator currently defines three Spectral ruleset configurations:
+  1. az-common.ts : for rules that apply to all Azure REST APIs
+  1. az-arm.ts: for rules that only apply to ARM REST APIs
+  1. az-dataplane.ts: for rules that only apply to dataplane REST APIs
+
+All rulesets reside in the `packages/rulesets/generated/spectral` folder of the repo.
+
+You can specify the ruleset directly on the command line:
+
+`spectral lint -r https://raw.githubusercontent.com/Azure/azure-openapi-validator/develop/packages/rulesets/generated/spectral/az-dataplane.js <api definition file>`
+
+Or you can create a Spectral configuration file (`.spectral.yaml`) that references the ruleset:
+
+```yaml
+extends:
+  - https://raw.githubusercontent.com/Azure/azure-openapi-validator/develop/packages/rulesets/generated/spectral/az-dataplane.js
+```
+
+### Example
+
+```bash
+spectral lint -r https://raw.githubusercontent.com/Azure/azure-openapi-validator/develop/packages/rulesets/generated/spectral/az-dataplane.js petstore.yaml
+```
+
+### Using the Spectral VSCode extension
+
+There is a [Spectral VSCode extension](https://marketplace.visualstudio.com/items?itemName=stoplight.spectral) that will run the Spectral linter on an open API definition file and show errors right within VSCode.  You can use this ruleset with the Spectral VSCode extension.
+
+1. Install the Spectral VSCode extension from the extensions tab in VSCode.
+2. Create a Spectral configuration file (`.spectral.yaml`) in the root directory of your project as shown above.
+3. Set `spectral.rulesetFile` to the name of this configuration file in your VSCode settings.
+
+Now when you open an API definition in this project, it should highlight lines with errors.
+You can also get a full list of problems in the file by opening the "Problems panel" with "View / Problems".
+In the Problems panel you can filter to show or hide errors, warnings, or infos.
+
 ## Troubleshooting
 
 [See common issues here](./troubleshooting.md)


### PR DESCRIPTION
This PR adds doc to README on how to use the Spectral rulesets with the Spectral CLI and VSCode extension.

I also made some small fixes to the CONTRIBUTING.md.