### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,12 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Prerequisites
 
-- Node (12.x or higher)
-- Node Package Manager
-- Typescript (3.7.0 or higher)
-- @Microsoft/Rush (5.x or hider)
+- [Node.js](https://nodejs.org/) (14.x or higher)
+- [@Microsoft/Rush](https://rushjs.io/) (5.x or hider)
+
+```bash
+npm install -g @microsoft/rush
+```
 
 ## Installing NPM dependencies
 


### PR DESCRIPTION
Updated prerequisites in CONTRIBUTING.md.
- Updated required version of Node as Node 12 is EOL.
- Removed npm from prereqs as it now comes with node.
- Removed typescript as it is installed from package.json
- Added rush install command.