### PR TITLE
Add SchemaTypeAndFormat rule with tests and doc

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -26,7 +26,7 @@ specifiers:
   '@stoplight/spectral-ruleset-migrator': ^1.7.1
   '@stoplight/spectral-rulesets': ~1.6.0
   '@stoplight/spectral-runtime': ^1.1.0
-  '@stoplight/types': 12.3.0
+  '@stoplight/types': ^13.5.0
   '@types/glob': ^7.2.0
   '@types/jest': ^27.0.6
   '@types/js-yaml': ^3.12.4
@@ -93,7 +93,7 @@ dependencies:
   '@stoplight/spectral-ruleset-migrator': 1.7.3
   '@stoplight/spectral-rulesets': 1.6.0
   '@stoplight/spectral-runtime': 1.1.2
-  '@stoplight/types': 12.3.0
+  '@stoplight/types': 13.6.0
   '@types/glob': 7.2.0
   '@types/jest': 27.4.1
   '@types/js-yaml': 3.12.7
@@ -1168,6 +1168,14 @@ packages:
   /@stoplight/types/12.3.0:
     resolution: {integrity: sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==}
     engines: {node: '>=8'}
+    dependencies:
+      '@types/json-schema': 7.0.10
+      utility-types: 3.10.0
+    dev: false
+
+  /@stoplight/types/13.6.0:
+    resolution: {integrity: sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==}
+    engines: {node: ^12.20 || >=14.13}
     dependencies:
       '@types/json-schema': 7.0.10
       utility-types: 3.10.0
@@ -7803,7 +7811,7 @@ packages:
     dev: false
 
   file:projects/openapi-validator-rulesets.tgz:
-    resolution: {integrity: sha512-ktO5KHLruJr2srWW8CU9RX72L5wQAgSkjfWxkho6LhNljUrJ9XaZvsR/RkEZ2p+LiqoelYv4u8CRDvBsadozFg==, tarball: file:projects/openapi-validator-rulesets.tgz}
+    resolution: {integrity: sha512-YCwiDngB/1oZ5WdvN0S4t6OAvdNqSowuMiRJ7XIn9btUe79zggMoP8qmcZeLjnH3Gn41tLdV+Q+ploHELfj4yQ==, tarball: file:projects/openapi-validator-rulesets.tgz}
     name: '@rush-temp/openapi-validator-rulesets'
     version: 0.0.0
     dependencies:
@@ -7818,6 +7826,7 @@ packages:
       '@stoplight/spectral-ruleset-migrator': 1.7.3
       '@stoplight/spectral-rulesets': 1.6.0
       '@stoplight/spectral-runtime': 1.1.2
+      '@stoplight/types': 13.6.0
       '@types/jest': 27.4.1
       '@types/js-yaml': 3.12.7
       '@types/jsonpath': 0.2.0
@@ -7858,7 +7867,7 @@ packages:
     dev: false
 
   file:projects/openapi-validator.tgz:
-    resolution: {integrity: sha512-0y7khmkuRlmOPG//3AXirOVc8qAHnLY2HZDJ6W/loTsDi9BEuslmsEYBg0RdhNHrg/BnRN53PuJjxQZRWpj1/Q==, tarball: file:projects/openapi-validator.tgz}
+    resolution: {integrity: sha512-+NEF+fHVObiSBEtXnfuYtFvXHMgWwFZVgjuXk/u5YqGUIorYvjp2BRsf6Rhn8dLuhm3zx5lUzKX2hfZ0/PM4uA==, tarball: file:projects/openapi-validator.tgz}
     name: '@rush-temp/openapi-validator'
     version: 0.0.0
     dependencies:
@@ -7879,7 +7888,7 @@ packages:
       '@stoplight/spectral-ruleset-migrator': 1.7.3
       '@stoplight/spectral-rulesets': 1.6.0
       '@stoplight/spectral-runtime': 1.1.2
-      '@stoplight/types': 12.3.0
+      '@stoplight/types': 13.6.0
       '@types/jest': 27.4.1
       '@types/js-yaml': 3.12.7
       '@types/jsonpath': 0.2.0

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -901,6 +901,47 @@ Schema names should be Pascal case. This includes any acronyms.
 
 Please refer to [schema-names-convention.md](./schema-names-convention.md) for details.
 
+### SchemaTypeAndFormat
+
+Every schema should specify a well-defined combination of `type` and `format`.
+`format` is required for type integer and number, optional for type string,
+and not allowed for any other types.
+The well-defined type/format combinations are:
+**type: integer**
+| format   | description     | comments                  |
+| -------- | --------------- | ------------------------- |
+| int32    | signed 32 bits  | from [oas2][oas2]         |
+| int64    | signed 64 bits  | from [oas2][oas2]         |
+| unixtime | Unix time stamp | from [autorest][autorest] |
+**type: number**
+| format  | description            | comments                  |
+| ------- | ---------------------- | ------------------------- |
+| float   | 32 bit floating point  | from [oas2][oas2]         |
+| int64   | 64 bit floating point  | from [oas2][oas2]         |
+| decimal | 128 bit floating point | from [autorest][autorest] |
+**type: string**
+| format            | description                  | comments                  |
+| ----------------- | ---------------------------- | ------------------------- |
+| byte              | base64 encoded characters    | from [oas2][oas2]         |
+| binary            | any sequence of octets       | from [oas2][oas2]         |
+| date              | [RFC3339][rfc3339] full-date | from [oas2][oas2]         |
+| date-time         | [RFC3339][rfc3339] date-time | from [oas2][oas2]         |
+| password          | sensitive value              | from [oas2][oas2]         |
+| char              |                              | from [autorest][autorest] |
+| time              |                              | from [autorest][autorest] |
+| date-time-rfc1123 |                              | from [autorest][autorest] |
+| duration          |                              | from [autorest][autorest] |
+| uuid              |                              | from [autorest][autorest] |
+| base64url         |                              | from [autorest][autorest] |
+| url               |                              | from [autorest][autorest] |
+| odata-query       |                              | from [autorest][autorest] |
+| certificate       |                              | from [autorest][autorest] |
+oas2: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types
+autorest: https://github.com/Azure/autorest/blob/main/packages/libs/openapi/src/v3/formats.ts
+rfc3339: https://xml2rfc.tools.ietf.org/public/rfc/
+
+Please refer to [schema-type-and-format.md](./schema-type-and-format.md) for details.
+
 ### SecurityDefinitionDescription
 
 All security definitions should have a description.

--- a/docs/schema-type-and-format.md
+++ b/docs/schema-type-and-format.md
@@ -1,0 +1,73 @@
+# SchemaTypeAndFormat
+
+## Category
+
+Data Plane Warning
+
+## Applies to
+
+Data Plane OpenAPI specs
+
+## Output Message
+
+Schema with type: {{type}} has unrecognized format: {{format}}
+
+## Description
+
+Every schema should specify a well-defined combination of `type` and `format`.
+
+`format` is required for type integer and number, optional for type string,
+and not allowed for any other types.
+
+The well-defined type/format combinations are:
+
+**type: integer**
+
+| format   | description     | comments                  |
+| -------- | --------------- | ------------------------- |
+| int32    | signed 32 bits  | from [oas2][oas2]         |
+| int64    | signed 64 bits  | from [oas2][oas2]         |
+| unixtime | Unix time stamp | from [autorest][autorest] |
+
+**type: number**
+
+| format  | description            | comments                  |
+| ------- | ---------------------- | ------------------------- |
+| float   | 32 bit floating point  | from [oas2][oas2]         |
+| int64   | 64 bit floating point  | from [oas2][oas2]         |
+| decimal | 128 bit floating point | from [autorest][autorest] |
+
+**type: string**
+
+| format            | description                  | comments                  |
+| ----------------- | ---------------------------- | ------------------------- |
+| byte              | base64 encoded characters    | from [oas2][oas2]         |
+| binary            | any sequence of octets       | from [oas2][oas2]         |
+| date              | [RFC3339][rfc3339] full-date | from [oas2][oas2]         |
+| date-time         | [RFC3339][rfc3339] date-time | from [oas2][oas2]         |
+| password          | sensitive value              | from [oas2][oas2]         |
+| char              |                              | from [autorest][autorest] |
+| time              |                              | from [autorest][autorest] |
+| date-time-rfc1123 |                              | from [autorest][autorest] |
+| duration          |                              | from [autorest][autorest] |
+| uuid              |                              | from [autorest][autorest] |
+| base64url         |                              | from [autorest][autorest] |
+| url               |                              | from [autorest][autorest] |
+| odata-query       |                              | from [autorest][autorest] |
+| certificate       |                              | from [autorest][autorest] |
+
+oas2: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types
+autorest: https://github.com/Azure/autorest/blob/main/packages/libs/openapi/src/v3/formats.ts
+rfc3339: https://xml2rfc.tools.ietf.org/public/rfc/
+
+## CreatedAt
+
+July 21, 2022
+
+## LastModifiedAt
+
+July 21, 2022
+
+## How to fix the violation
+
+Change the schema to use a well-defined type and format.

--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -61,7 +61,7 @@
     "@stoplight/path": "1.3.2",
     "@stoplight/spectral-parsers": "^1.0.0",
     "@stoplight/spectral-ref-resolver": "^1.0.0",
-    "@stoplight/types": "12.3.0",
+    "@stoplight/types": "^13.5.0",
     "dependency-graph": "^0.11.0",
     "@microsoft.azure/openapi-validator-core": "^1.0.0-beta.1",
     "@microsoft.azure/openapi-validator-rulesets": "^1.0.0-beta.1",

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -52,6 +52,7 @@
     "@stoplight/spectral-ruleset-bundler": "^1.2.1",
     "@stoplight/spectral-rulesets": "~1.6.0",
     "@stoplight/spectral-runtime": "^1.1.0",
+    "@stoplight/types": "^13.5.0",
     "@rollup/plugin-json": "^4.1.0",
     "jest": "^27.0.6",
     "ts-jest": "^27.1.3",

--- a/packages/rulesets/src/spectral/az-dataplane.ts
+++ b/packages/rulesets/src/spectral/az-dataplane.ts
@@ -17,6 +17,7 @@ import paramorder from "./functions/param-order"
 import patchcontenttype from "./functions/patch-content-type"
 import pathparamnames from "./functions/path-param-names"
 import pathparamschema from "./functions/path-param-schema"
+import schematypeandformat from "./functions/schema-type-and-format"
 import versionpolicy from "./functions/version-policy"
 const ruleset: any = {
   extends: [common],
@@ -399,6 +400,19 @@ const ruleset: any = {
         functionOptions: {
           type: "pascal",
         },
+      },
+    },
+    SchemaTypeAndFormat: {
+      description: "Schema should use well-defined type and format.",
+      message: "{{error}}",
+      severity: "warn",
+      formats: [oas2],
+      given: [
+        "$.paths[*].[put,post,patch].parameters.[?(@.in == 'body')].schema",
+        "$.paths[*].[get,put,post,patch,delete].responses[*].schema",
+      ],
+      then: {
+        function: schematypeandformat,
       },
     },
     SecurityDefinitionDescription: {

--- a/packages/rulesets/src/spectral/functions/schema-type-and-format.ts
+++ b/packages/rulesets/src/spectral/functions/schema-type-and-format.ts
@@ -1,0 +1,104 @@
+// Check that format is valid for a schema type.
+// Valid formats are those defined in the OpenAPI spec and extensions in autorest.
+// - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types
+// - https://github.com/Azure/autorest/blob/main/packages/libs/openapi/src/v3/formats.ts
+
+import type { IFunctionResult } from "@stoplight/spectral-core"
+import type { JsonPath } from "@stoplight/types"
+
+type Oas2Schema = {
+  type: string
+  format: string
+  properties: { [key: string]: Oas2Schema }
+  allOf: Oas2Schema[]
+}
+
+// `input` is the schema of a request or response body
+function checkSchemaTypeAndFormat(schema: Oas2Schema, options: any, { path }: { path: JsonPath }): IFunctionResult[] {
+  if (schema === null || typeof schema !== "object") {
+    return [] as IFunctionResult[]
+  }
+
+  const errors: IFunctionResult[] = []
+
+  const stringFormats = [
+    // OAS-defined formats
+    "byte",
+    "binary",
+    "date",
+    "date-time",
+    "password",
+    // Additional formats recognized by autorest
+    "char",
+    "time",
+    "date-time-rfc1123",
+    "duration",
+    "uuid",
+    "base64url",
+    "url",
+    "odata-query",
+    "certificate",
+  ]
+
+  if (schema.type === "string") {
+    if (schema.format) {
+      if (!stringFormats.includes(schema.format)) {
+        errors.push({
+          message: `Schema with type: string has unrecognized format: ${schema.format}`,
+          path: [...path, "format"],
+        })
+      }
+    }
+  } else if (schema.type === "integer") {
+    if (schema.format) {
+      if (!["int32", "int64", "unixtime"].includes(schema.format)) {
+        errors.push({
+          message: `Schema with type: integer has unrecognized format: ${schema.format}`,
+          path: [...path, "format"],
+        })
+      }
+    } else {
+      errors.push({
+        message: "Schema with type: integer should specify format",
+        path,
+      })
+    }
+  } else if (schema.type === "number") {
+    if (schema.format) {
+      if (!["float", "double", "decimal"].includes(schema.format)) {
+        errors.push({
+          message: `Schema with type: number has unrecognized format: ${schema.format}`,
+          path: [...path, "format"],
+        })
+      }
+    } else {
+      errors.push({
+        message: "Schema with type: number should specify format",
+        path,
+      })
+    }
+  } else if (schema.type === "boolean") {
+    if (schema.format) {
+      errors.push({
+        message: "Schema with type: boolean should not specify format",
+        path: [...path, "format"],
+      })
+    }
+  } else if (schema.properties && typeof schema.properties === "object") {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [key, value] of Object.entries(schema.properties)) {
+      errors.push(...checkSchemaTypeAndFormat(value, options, { path: [...path, "properties", key] }))
+    }
+  }
+
+  if (schema.allOf && Array.isArray(schema.allOf)) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [index, value] of schema.allOf.entries()) {
+      errors.push(...checkSchemaTypeAndFormat(value, options, { path: [...path, "allOf", index] }))
+    }
+  }
+
+  return errors
+}
+
+export default checkSchemaTypeAndFormat

--- a/packages/rulesets/src/spectral/test/schema-type-and-format.test.ts
+++ b/packages/rulesets/src/spectral/test/schema-type-and-format.test.ts
@@ -1,0 +1,245 @@
+import { Spectral } from "@stoplight/spectral-core"
+import linterForRule from "./utils"
+
+let linter: Spectral
+
+beforeAll(async () => {
+  linter = await linterForRule("SchemaTypeAndFormat")
+  return linter
+})
+
+test("az-schema-type-and-format should find errors", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/test1": {
+        post: {
+          parameters: [
+            {
+              name: "version",
+              in: "body",
+              schema: {
+                type: "object",
+                properties: {
+                  prop1: {
+                    type: "integer",
+                    format: "int52",
+                  },
+                  prop2: {
+                    type: "object",
+                    properties: {
+                      prop3: {
+                        type: "string",
+                        format: "special",
+                      },
+                    },
+                  },
+                  prop3: {
+                    type: "boolean",
+                    format: "yes-or-no",
+                  },
+                  prop4: {
+                    type: "number",
+                  },
+                },
+                allOf: [
+                  {
+                    properties: {
+                      prop5: {
+                        type: "string",
+                        format: "email",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+              schema: {
+                $ref: "#/definitions/Model1",
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      Model1: {
+        type: "object",
+        properties: {
+          propW: {
+            type: "number",
+            format: "exponential",
+          },
+          propX: {
+            type: "object",
+            properties: {
+              propY: {
+                type: "string",
+                format: "secret",
+              },
+            },
+          },
+          propZ: {
+            type: "integer",
+          },
+          propZZ: {
+            $ref: "#/definitions/PropZZ",
+          },
+        },
+        allOf: [
+          {
+            $ref: "#/definitions/ModelA",
+          },
+        ],
+      },
+      PropZZ: {
+        type: "string",
+        format: "ZZTop",
+      },
+      ModelA: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "guid",
+          },
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(10)
+    expect(results[0].path.join(".")).toBe("paths./test1.post.parameters.0.schema.properties.prop1.format")
+    expect(results[0].message).toBe("Schema with type: integer has unrecognized format: int52")
+    expect(results[1].path.join(".")).toBe("paths./test1.post.parameters.0.schema.properties.prop2.properties.prop3.format")
+    expect(results[1].message).toBe("Schema with type: string has unrecognized format: special")
+    expect(results[2].path.join(".")).toBe("paths./test1.post.parameters.0.schema.properties.prop3.format")
+    expect(results[2].message).toBe("Schema with type: boolean should not specify format")
+    expect(results[3].path.join(".")).toBe("paths./test1.post.parameters.0.schema.properties.prop4")
+    expect(results[3].message).toBe("Schema with type: number should specify format")
+    expect(results[4].path.join(".")).toBe("paths./test1.post.parameters.0.schema.allOf.0.properties.prop5.format")
+    expect(results[4].message).toBe("Schema with type: string has unrecognized format: email")
+    expect(results[5].path.join(".")).toBe("paths./test1.post.responses.200.schema.allOf.0.properties.id.format")
+    expect(results[5].message).toBe("Schema with type: string has unrecognized format: guid")
+    expect(results[6].path.join(".")).toBe("paths./test1.post.responses.200.schema.properties.propW.format")
+    expect(results[6].message).toBe("Schema with type: number has unrecognized format: exponential")
+    expect(results[7].path.join(".")).toBe("paths./test1.post.responses.200.schema.properties.propX.properties.propY.format")
+    expect(results[7].message).toBe("Schema with type: string has unrecognized format: secret")
+    expect(results[8].path.join(".")).toBe("paths./test1.post.responses.200.schema.properties.propZ")
+    expect(results[8].message).toBe("Schema with type: integer should specify format")
+    expect(results[9].path.join(".")).toBe("paths./test1.post.responses.200.schema.properties.propZZ.format")
+    expect(results[9].message).toBe("Schema with type: string has unrecognized format: ZZTop")
+  })
+})
+
+test("az-schema-type-and-format should find no errors", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/test1": {
+        post: {
+          parameters: [
+            {
+              name: "version",
+              in: "body",
+              schema: {
+                type: "object",
+                properties: {
+                  prop1: {
+                    type: "integer",
+                    format: "int64",
+                  },
+                  prop2: {
+                    type: "object",
+                    properties: {
+                      prop3: {
+                        type: "string",
+                        format: "byte",
+                      },
+                    },
+                  },
+                  prop3: {
+                    type: "boolean",
+                  },
+                  prop4: {
+                    type: "number",
+                    format: "float",
+                  },
+                },
+                allOf: [
+                  {
+                    properties: {
+                      prop5: {
+                        type: "string",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+              schema: {
+                $ref: "#/definitions/Model1",
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      Model1: {
+        type: "object",
+        properties: {
+          propW: {
+            type: "number",
+            format: "double",
+          },
+          propX: {
+            type: "object",
+            properties: {
+              propY: {
+                type: "string",
+                format: "duration",
+              },
+            },
+          },
+          propZ: {
+            type: "integer",
+            format: "int32",
+          },
+          propZZ: {
+            $ref: "#/definitions/PropZZ",
+          },
+          allOf: [
+            {
+              $ref: "#/definitions/ModelA",
+            },
+          ],
+        },
+      },
+      PropZZ: {
+        type: "string",
+        format: "url",
+      },
+      ModelA: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR adds a rule to check that the type and format combination for a schema is well-defined.