### PR TITLE
Organizing ARM linter rules

### DIFF
--- a/docs/all-resources-must-have-delete.md
+++ b/docs/all-resources-must-have-delete.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-DELETE-02
+- RPC-Delete-V1-03
 
 ## Output Message
 

--- a/docs/all-resources-must-have-get-operation.md
+++ b/docs/all-resources-must-have-get-operation.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-04
+- RPC-Get-V1-04
 
 ## Output Message
 

--- a/docs/api-version-parameter-required.md
+++ b/docs/api-version-parameter-required.md
@@ -10,11 +10,11 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-9
+- RPC-Uri-V1-08
 
 ## Description
 
-This rule applies when the 'api-version' parameter is missing in any operations.
+Operation is missing the 'api-version' parameter.
 
 ## How to fix
 

--- a/docs/arm-resource-properties-bag.md
+++ b/docs/arm-resource-properties-bag.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-04
+- RPC-Get-V1-07
 
 ## Output Message
 

--- a/docs/body-top-level-properties.md
+++ b/docs/body-top-level-properties.md
@@ -11,7 +11,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-6
+- RPC-Put-V1-06
 
 ## Output Message
 

--- a/docs/consistent-patch-properties.md
+++ b/docs/consistent-patch-properties.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-3
+- RPC-Patch-V1-03
 
 ## Output Message
 

--- a/docs/create-operation-async-response-validation.md
+++ b/docs/create-operation-async-response-validation.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-1
+- RPC-Async-V1-01
 
 ## Output Message
 

--- a/docs/delete-must-not-have-request-body.md
+++ b/docs/delete-must-not-have-request-body.md
@@ -8,6 +8,10 @@ SDK Error
 
 ARM and Data plane OpenAPI(swagger) specs
 
+## Related ARM Guideline Code
+
+- RPC-Delete-V1-02
+
 ## Output Message
 
 'Delete' operation '{0}' must not have a request body.

--- a/docs/delete-operation-async-response-validation.md
+++ b/docs/delete-operation-async-response-validation.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-9
+- RPC-Async-V1-09
 
 ## Output Message
 

--- a/docs/delete-operation-responses.md
+++ b/docs/delete-operation-responses.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-DELETE-01
+- RPC-Delete-V1-01
 
 ## Output Message
 

--- a/docs/delete-response-body-empty.md
+++ b/docs/delete-response-body-empty.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Delete-04
+- RPC-Delete-V1-04
 
 ## Output Message
 

--- a/docs/get-operation200.md
+++ b/docs/get-operation200.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-01
+- RPC-Get-V1-01
 
 ## Output Message
 

--- a/docs/location-must-have-xms-mutability.md
+++ b/docs/location-must-have-xms-mutability.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-14
+- RPC-Put-V1-14
 
 ## Output Message
 

--- a/docs/long-running-operations-options-validator.md
+++ b/docs/long-running-operations-options-validator.md
@@ -10,7 +10,7 @@ ARM and Data Plane OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-5
+- RPC-Async-V1-05
 
 ## Output Message
 

--- a/docs/long-running-operations-with-long-running-extension.md
+++ b/docs/long-running-operations-with-long-running-extension.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-5
+- RPC-Async-V1-05
 
 ## Output Message
 

--- a/docs/long-running-response-status-code-data-plane.md
+++ b/docs/long-running-response-status-code-data-plane.md
@@ -10,7 +10,7 @@ ARM and Data plane OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-1
+- RPC-Async-V1-01
 
 ## Output Message
 

--- a/docs/long-running-response-status-code.md
+++ b/docs/long-running-response-status-code.md
@@ -10,7 +10,7 @@ ARM and Data plane OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-1
+- RPC-Async-V1-01
 
 ## Output Message
 

--- a/docs/lro-location-header.md
+++ b/docs/lro-location-header.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-7
+- RPC-Async-V1-07
 
 ## Output Message
 

--- a/docs/lro-patch202.md
+++ b/docs/lro-patch202.md
@@ -10,8 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-6
-- RPC-V2-ASYNC-8
+- RPC-Patch-V1-06, RPC-Async-V1-08
 
 ## Output Message
 

--- a/docs/next-link-property-must-exist.md
+++ b/docs/next-link-property-must-exist.md
@@ -10,7 +10,7 @@ ARM and Data plane OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-06
+- RPC-Get-V1-06
 
 ## Output Message
 

--- a/docs/patch-body-parameters-schema.md
+++ b/docs/patch-body-parameters-schema.md
@@ -10,7 +10,7 @@ ARM and Data plane OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-10
+- RPC-Patch-V1-10
 
 ## Output Message
 

--- a/docs/patch-identity-property.md
+++ b/docs/patch-identity-property.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-11
+- RPC-Patch-V1-11
 
 ## Output Message
 

--- a/docs/patch-sku-property.md
+++ b/docs/patch-sku-property.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-9
+- RPC-Patch-V1-09
 
 ## Output Message
 

--- a/docs/path-contains-resource-group.md
+++ b/docs/path-contains-resource-group.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-2
+- RPC-Uri-V1-02
 
 ## Output Message
 

--- a/docs/path-contains-resource-type.md
+++ b/docs/path-contains-resource-type.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-4
+- RPC-Uri-V1-04
 
 ## Output Message
 

--- a/docs/path-contains-subscription-id.md
+++ b/docs/path-contains-subscription-id.md
@@ -10,11 +10,11 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-1
+- RPC-Uri-V1-01
 
 ## Output Message
 
-The path for the subscriptions scoped CRUD methods do not contain the subscriptionId parameter.
+The path for the resource group scoped CRUD methods do not contain the subscriptionId parameter.
 
 ## Description
 

--- a/docs/path-for-nested-resource.md
+++ b/docs/path-for-nested-resource.md
@@ -10,8 +10,8 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-6
-- RPC-V2-PUT-2
+- RPC-Uri-V1-06
+- RPC-Put-V1-02
 
 ## Output Message
 

--- a/docs/path-for-put-operation.md
+++ b/docs/path-for-put-operation.md
@@ -10,8 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-7
-- RPC-V2-PUT-1
+- RPC-Put-V1-01
 
 ## Output Message
 

--- a/docs/path-for-resource-action.md
+++ b/docs/path-for-resource-action.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-7
+- RPC-Uri-V1-07
 
 ## Output Message
 

--- a/docs/path-resource-provider-match-namespace.md
+++ b/docs/path-resource-provider-match-namespace.md
@@ -10,15 +10,15 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-3
+- RPC-Uri-V1-03
 
 ## Output Message
 
-The last resource provider '{0}' doesn't match the namespace.
+The resource provider namespace name '{0}' in the path doesn't match the namespace name to which the specification file belongs.
 
 ## Description
 
-Verifies whether the last resource provider matches namespace or not. E.g the path /providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.Insights/extResource/{extType}' is allowed only if Microsoft.Insights matches the namespace (Microsoft.Insights).
+Verifies whether the resource provider namespace in the last segment of the path matches the namespace to which the specification file belongs. E.g the path /providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.Insights/extResource/{extType}' is allowed only if the segment /Microsoft.Insights matches the namespace name to which the specification file belongs (Microsoft.Insights).
 
 ## Why the rule is important
 

--- a/docs/post-operation-async-response-validation.md
+++ b/docs/post-operation-async-response-validation.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-11
+- RPC-Async-V1-11
 
 ## Output Message
 

--- a/docs/provisioning-state-validation.md
+++ b/docs/provisioning-state-validation.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-ASYNC-03
+- RPC-Async-V1-03
 
 ## Output Message
 

--- a/docs/put-get-patch-response-schema.md
+++ b/docs/put-get-patch-response-schema.md
@@ -10,7 +10,7 @@ ARM and Data plane OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-12
+- RPC-Put-V1-12
 
 ## Output Message
 

--- a/docs/repeated-path-info.md
+++ b/docs/repeated-path-info.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-5
+- RPC-Put-V1-05
 
 ## Output Message
 

--- a/docs/required-properties-missing-in-resource-model.md
+++ b/docs/required-properties-missing-in-resource-model.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-03
+- RPC-Get-V1-03, RPC-Put-V1-08
 
 ## Output Message
 

--- a/docs/resource-name-restriction.md
+++ b/docs/resource-name-restriction.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-URI-5
+- RPC-Uri-V1-05
 
 ## Output Message
 

--- a/docs/top-level-resources-list-by-resource-group.md
+++ b/docs/top-level-resources-list-by-resource-group.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-05
+- RPC-Get-V1-05
 
 ## Output Message
 

--- a/docs/top-level-resources-list-by-subscription.md
+++ b/docs/top-level-resources-list-by-subscription.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-GET-05
+- RPC-Get-V1-05
 
 ## Output Message
 

--- a/docs/tracked-resource-beyond-thrid-level.md
+++ b/docs/tracked-resource-beyond-thrid-level.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-19
+- RPC-Put-V1-19
 
 ## Output Message
 

--- a/docs/tracked-resource-patch-operation.md
+++ b/docs/tracked-resource-patch-operation.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-3
+- RPC-Patch-V1-03
 
 ## Output Message
 

--- a/docs/tracked-resources-must-have-put.md
+++ b/docs/tracked-resources-must-have-put.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-22
+- RPC-Put-V1-22
 
 ## Output Message
 

--- a/docs/un-supported-patch-properties.md
+++ b/docs/un-supported-patch-properties.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-Patch-2
+- RPC-Patch-V1-02
 
 ## Output Message
 

--- a/docs/xms-long-running-operation-options.md
+++ b/docs/xms-long-running-operation-options.md
@@ -8,6 +8,10 @@ ARM Warning
 
 ARM OpenAPI(swagger) specs
 
+## Related ARM Guideline Code
+
+- RPC-Async-V1-06
+
 ## Output Message
 
 The x-ms-long-running-operation-options should be specified explicitly to indicate the type of response header to track the async operation.

--- a/docs/xms-resource-in-put-response.md
+++ b/docs/xms-resource-in-put-response.md
@@ -10,7 +10,7 @@ ARM OpenAPI(swagger) specs
 
 ## Related ARM Guideline Code
 
-- RPC-V2-PUT-12
+- RPC-Put-V1-12
 
 ## Output Message
 

--- a/packages/rulesets/src/native/legacyRules/AllResourcesMustHaveGetOperation.ts
+++ b/packages/rulesets/src/native/legacyRules/AllResourcesMustHaveGetOperation.ts
@@ -3,6 +3,7 @@ import { JsonPath, rules, MergeStates, OpenApiTypes } from "@microsoft.azure/ope
 import { ArmHelper } from "../utilities/arm-helper"
 export const AllResourcesMustHaveGetOperation = "AllResourcesMustHaveGetOperation"
 
+// RPC Code: RPC-Get-V1-04
 rules.push({
   id: "R4014",
   name: AllResourcesMustHaveGetOperation,

--- a/packages/rulesets/src/native/legacyRules/DeleteOperationAsyncResponseValidation.ts
+++ b/packages/rulesets/src/native/legacyRules/DeleteOperationAsyncResponseValidation.ts
@@ -6,6 +6,7 @@ import { MergeStates, OpenApiTypes, rules } from "@microsoft.azure/openapi-valid
 export const DeleteOperationAsyncResponseValidation = "DeleteOperationAsyncResponseValidation"
 
 rules.push({
+  // RPC Code: RPC-Async-V1-09
   id: "R4025",
   name: DeleteOperationAsyncResponseValidation,
   severity: "error",

--- a/packages/rulesets/src/native/legacyRules/DeleteOperationResponses.ts
+++ b/packages/rulesets/src/native/legacyRules/DeleteOperationResponses.ts
@@ -5,6 +5,7 @@
 import { MergeStates, OpenApiTypes, rules } from "@microsoft.azure/openapi-validator-core"
 export const DeleteOperationResponses = "DeleteOperationResponses"
 
+// RPC Code: RPC-Delete-V1-01
 rules.push({
   id: "R4011",
   name: DeleteOperationResponses,

--- a/packages/rulesets/src/native/legacyRules/PostOperationAsyncResponseValidation.ts
+++ b/packages/rulesets/src/native/legacyRules/PostOperationAsyncResponseValidation.ts
@@ -5,6 +5,7 @@
 import { MergeStates, OpenApiTypes, rules } from "@microsoft.azure/openapi-validator-core"
 export const PostOperationAsyncResponseValidation = "PostOperationAsyncResponseValidation"
 
+// RPC Code: RPC-Async-V1-11
 rules.push({
   id: "R4026",
   name: PostOperationAsyncResponseValidation,

--- a/packages/rulesets/src/native/legacyRules/TopLevelResourcesListByResourceGroup.ts
+++ b/packages/rulesets/src/native/legacyRules/TopLevelResourcesListByResourceGroup.ts
@@ -3,6 +3,7 @@ import { JsonPath, rules, MergeStates, OpenApiTypes } from "@microsoft.azure/ope
 import { ArmHelper } from "../utilities/arm-helper"
 export const TopLevelResourcesListByResourceGroup = "TopLevelResourcesListByResourceGroup"
 
+// RPC Code: RPC-Get-V1-05
 rules.push({
   id: "R4016",
   name: TopLevelResourcesListByResourceGroup,

--- a/packages/rulesets/src/native/legacyRules/TopLevelResourcesListBySubscription.ts
+++ b/packages/rulesets/src/native/legacyRules/TopLevelResourcesListBySubscription.ts
@@ -3,6 +3,7 @@ import { JsonPath, rules, MergeStates, OpenApiTypes } from "@microsoft.azure/ope
 import { ArmHelper } from "../utilities/arm-helper"
 export const TopLevelResourcesListBySubscription = "TopLevelResourcesListBySubscription"
 
+// RPC Code: RPC-Get-V1-05
 rules.push({
   id: "R4017",
   name: TopLevelResourcesListBySubscription,

--- a/packages/rulesets/src/native/rulesets/arm.ts
+++ b/packages/rulesets/src/native/rulesets/arm.ts
@@ -14,25 +14,13 @@ import { providerNamespace } from "../functions/provider-namespace"
 export const armRuleset: IRuleSet = {
   documentationUrl: "https://github.com/Azure/azure-openapi-validator/blob/develop/docs/rules.md",
   rules: {
-    TrackedResourcesMustHavePut: {
-      category: "ARMViolation",
-      openapiType: OpenApiTypes.arm,
-      severity: "error",
-      given: "$",
-      then: {
-        execute: trackedResourcesMustHavePut,
-      },
-    },
-    TrackedResourceBeyondsThirdLevel: {
-      category: "ARMViolation",
-      openapiType: OpenApiTypes.arm,
-      severity: "error",
-      given: "$",
-      then: {
-        execute: trackedResourceBeyondsThirdLevel,
-      },
-    },
+
+    ///
+    /// ARM RPC rules for Delete patterns
+    ///
+
     // https://github.com/Azure/azure-openapi-validator/issues/329
+    // RPC Code: RPC-Delete-V1-03
     AllResourcesMustHaveDelete: {
       category: "ARMViolation",
       openapiType: OpenApiTypes.arm,
@@ -42,6 +30,23 @@ export const armRuleset: IRuleSet = {
         execute: allResourcesHaveDelete,
       },
     },
+
+    ///
+    /// ARM RPC rules for Get patterns
+    ///
+
+    // RPC Code: RPC-Get-V1-03, RPC-Put-V1-08
+    RequiredPropertiesMissingInResourceModel: {
+      description: `Per [ARM guidelines](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md), a 'Resource' model must have the 'name', 'id' and 'type' properties defined as 'readOnly' in its hierarchy.`,
+      category: "ARMViolation",
+      openapiType: OpenApiTypes.arm,
+      severity: "error",
+      given: "$",
+      then: {
+        execute: resourcesHaveRequiredProperties,
+      },
+    },
+    // RPC Code: RPC-Get-V1-07
     ArmResourcePropertiesBag: {
       description:
         "Per [ARM guidelines](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md), top level properties should not be repeated inside the properties bag for ARM resources.",
@@ -53,6 +58,12 @@ export const armRuleset: IRuleSet = {
         execute: armResourcePropertiesBag,
       },
     },
+
+    ///
+    /// ARM RPC rules for Put patterns
+    ///
+
+    // RPC Code: RPC-Put-V1-06, RPC-Get-V1-02
     BodyTopLevelProperties: {
       description:
         "Per [ARM guidelines](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md), top level properties of a resource should be only ones from the allowed set.",
@@ -64,6 +75,46 @@ export const armRuleset: IRuleSet = {
         execute: bodyTopLevelProperties,
       },
     },
+    // RPC Code: RPC-Put-V1-19
+    TrackedResourceBeyondsThirdLevel: {
+      category: "ARMViolation",
+      openapiType: OpenApiTypes.arm,
+      severity: "error",
+      given: "$",
+      then: {
+        execute: trackedResourceBeyondsThirdLevel,
+      },
+    },
+    // RPC Code: RPC-Put-V1-22
+    TrackedResourcesMustHavePut: {
+      category: "ARMViolation",
+      openapiType: OpenApiTypes.arm,
+      severity: "error",
+      given: "$",
+      then: {
+        execute: trackedResourcesMustHavePut,
+      },
+    },
+
+    ///
+    /// ARM RPC rules for Uri path patterns
+    ///
+
+    // RPC Code: RPC-Uri-V1-03
+    PathResourceProviderMatchNamespace: {
+      description: `Verifies whether the last resource provider matches namespace or not. E.g the path /providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.Insights/extResource/{extType}' is allowed only if Microsoft.Insights matches the namespace (Microsoft.Insights).`,
+      severity: "error",
+      category: "ARMViolation",
+      openapiType: OpenApiTypes.arm,
+      given: ["$[paths,'x-ms-paths'].*~"],
+      then: {
+        execute: providerNamespace,
+      },
+    },
+
+    ///
+    /// ARM rules wthout an RPC code
+    ///
     OperationsAPIImplementation: {
       description:
         "Per [ARM guidelines](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md), each RP must expose an operations API that returns information about all the operations available with the service.",
@@ -76,16 +127,6 @@ export const armRuleset: IRuleSet = {
         execute: operationsAPIImplementation,
       },
     },
-    RequiredPropertiesMissingInResourceModel: {
-      description: `Per [ARM guidelines](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md), a 'Resource' model must have the 'name', 'id' and 'type' properties defined as 'readOnly' in its hierarchy.`,
-      category: "ARMViolation",
-      openapiType: OpenApiTypes.arm,
-      severity: "error",
-      given: "$",
-      then: {
-        execute: resourcesHaveRequiredProperties,
-      },
-    },
     // https://github.com/Azure/azure-openapi-validator/issues/329
     TrackedResourcePatchOperation: {
       category: "ARMViolation",
@@ -94,16 +135,6 @@ export const armRuleset: IRuleSet = {
       given: "$",
       then: {
         execute: trackedResourcesHavePatch,
-      },
-    },
-    PathResourceProviderMatchNamespace: {
-      description: `Verifies whether the last resource provider matches namespace or not. E.g the path /providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.Insights/extResource/{extType}' is allowed only if Microsoft.Insights matches the namespace (Microsoft.Insights).`,
-      severity: "error",
-      category: "ARMViolation",
-      openapiType: OpenApiTypes.arm,
-      given: ["$[paths,'x-ms-paths'].*~"],
-      then: {
-        execute: providerNamespace,
       },
     },
     XmsPageableListByRGAndSubscriptions: {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -129,7 +129,7 @@ const ruleset: any = {
     },
     // https://github.com/Azure/azure-openapi-validator/issues/332
     ProvisioningStateValidation: {
-      description: "ProvisioningState must have terminal states: Succeeded, Failed and Canceled.",
+      description: "[RPC-V1-ASYNC-03] ProvisioningState must have terminal states: Succeeded, Failed and Canceled.",
       message: "{{error}}",
       severity: "error",
       resolved: false,

--- a/packages/rulesets/src/spectral/az-common.ts
+++ b/packages/rulesets/src/spectral/az-common.ts
@@ -283,6 +283,7 @@ const ruleset: any = {
         function: mutabilityWithReadOnly,
       },
     },
+    // RPC Code: RPC-Get-V1-06
     NextLinkPropertyMustExist: {
       description:
         "Per definition of AutoRest x-ms-pageable extension, the property specified by nextLinkName must exist in the 200 response schema.",

--- a/src/typescript/azure-openapi-validator/rules/AllResourcesMustHaveGetOperation.ts
+++ b/src/typescript/azure-openapi-validator/rules/AllResourcesMustHaveGetOperation.ts
@@ -4,6 +4,7 @@ import { MergeStates, OpenApiTypes } from "../rule"
 import { ResourceUtils } from "./utilities/resourceUtils"
 export const AllResourcesMustHaveGetOperation: string = "AllResourcesMustHaveGetOperation"
 
+// RPC Code: RPC-Get-V1-04
 rules.push({
   id: "R4014",
   name: AllResourcesMustHaveGetOperation,

--- a/src/typescript/azure-openapi-validator/rules/DeleteOperationResponses.ts
+++ b/src/typescript/azure-openapi-validator/rules/DeleteOperationResponses.ts
@@ -5,6 +5,7 @@
 import { MergeStates, OpenApiTypes, rules } from "../rule"
 export const DeleteOperationResponses: string = "DeleteOperationResponses"
 
+// RPC Code: RPC-Delete-V1-01
 rules.push({
   id: "R4011",
   name: DeleteOperationResponses,

--- a/src/typescript/azure-openapi-validator/rules/TopLevelResourcesListByResourceGroup.ts
+++ b/src/typescript/azure-openapi-validator/rules/TopLevelResourcesListByResourceGroup.ts
@@ -4,6 +4,7 @@ import { MergeStates, OpenApiTypes } from "../rule"
 import { ResourceUtils } from "./utilities/resourceUtils"
 export const TopLevelResourcesListByResourceGroup: string = "TopLevelResourcesListByResourceGroup"
 
+// RPC Code: RPC-Get-V1-05
 rules.push({
   id: "R4016",
   name: TopLevelResourcesListByResourceGroup,


### PR DESCRIPTION
Added the RPC codes with the new nomenclature and also arranged the rule implementation in alphabetic order within the file for easy discoverability