### PR TITLE
Use 1ES pools

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,6 +9,7 @@ variables:
 jobs:
   - job: 'Build'
     pool:
+      name: 'azsdk-pool-mms-ubuntu-2204-general'
       vmImage: 'ubuntu-22.04'
 
     steps:
@@ -33,6 +34,7 @@ jobs:
   - job: Windows
     displayName: credentialScan
     pool:
+      name: "azsdk-pool-mms-win-2019-general"
       vmImage: "windows-2019"
 
     steps:

--- a/azure-pipelines/lint-regression.yml
+++ b/azure-pipelines/lint-regression.yml
@@ -10,6 +10,7 @@ jobs:
 - job: regression_test
   timeoutInMinutes: 0
   pool:
+    name: "azsdk-pool-mms-ubuntu-2204-general"
     vmImage: "ubuntu-22.04"
 
   variables:

--- a/azure-pipelines/prod-release-pipelines.yml
+++ b/azure-pipelines/prod-release-pipelines.yml
@@ -4,6 +4,7 @@ variables:
 jobs:
   - job: 'Release_Build'
     pool:
+      name: 'azsdk-pool-mms-ubuntu-2204-general'
       vmImage: 'ubuntu-22.04'
 
     steps:

--- a/azure-pipelines/staging-release-pipelines.yml
+++ b/azure-pipelines/staging-release-pipelines.yml
@@ -4,6 +4,7 @@ variables:
 jobs:
 - job: 'Staging_Release_Build'
   pool:
+    name: 'azsdk-pool-mms-ubuntu-2204-general'
     vmImage: 'ubuntu-22.04'
 
   steps:


### PR DESCRIPTION
All Windows and Linux pipelines should use 1ES pools by default, unless they need to run in the DevOps Pool for a specific reason.