### PR TITLE
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,8 +34,8 @@ jobs:
   - job: Windows
     displayName: credentialScan
     pool:
-      name: "azsdk-pool-mms-win-2019-general"
-      vmImage: "windows-2019"
+      name: azsdk-pool-mms-win-2022-general
+      vmImage: windows-2022
 
     steps:
       - task: ea576cd4-c61f-48f8-97e7-a3cb07b90a6f@2 # CredScan@2  


### PR DESCRIPTION
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format.

This discussion explains why we chose given `vmImage` format:

[Mike Harder: 1ES Hosted Pool image name changes](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1676491855184?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1676491855184&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1676491855184)
posted in Azure SDK / Engineering System 🛠️ at Wednesday, February 15, 2023 12:10 PM

For further context, please see:
- https://github.com/Azure/azure-sdk-tools/issues/3407