### PR TITLE
Affix `-rulesets` package dependency to `1.0.1` and update `-core` package to `1.0.1`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 In preparation for deployment of pending ruleset changes to production,
 affixed package `@microsoft.azure/openapi-validator-rulesets` version used by `@microsoft.azure/openapi-validator`
-to be exactly `1.0.1`.
+to be exactly `1.0.1`. Also updated `@microsoft.azure/openapi-validator-core` to be `1.0.1`.
 
 For details, see:  
   Deploy pending azure-openapi-validator (LintDiff) changes from staging to prod #6071

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New (05/01/2023)
+
+In preparation for deployment of pending ruleset changes to production,
+affixed package `@microsoft.azure/openapi-validator-rulesets` version used by `@microsoft.azure/openapi-validator`
+to be exactly `1.0.1`.
+
+For details, see:  
+  Deploy pending azure-openapi-validator (LintDiff) changes from staging to prod #6071
+  https://github.com/Azure/azure-sdk-tools/issues/6071
+
 ## What's New (09/26/2022)
 
 ### Changed Rule

--- a/common/changes/@microsoft.azure/openapi-validator-core/update-to-1.0.1_2023_05_01.json
+++ b/common/changes/@microsoft.azure/openapi-validator-core/update-to-1.0.1_2023_05_01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-core",
+      "comment": "Update to 1.0.1. See https://github.com/Azure/azure-sdk-tools/issues/6071",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-core"
+}

--- a/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.0.1-update-core-to-1.0.1_2023-05-01.json
+++ b/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.0.1-update-core-to-1.0.1_2023-05-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator",
-      "comment": "affix rulesets used to 1.0.1 and update core to 1.0.1. See https://github.com/Azure/azure-sdk-tools/issues/6071",
+      "comment": "Affix rulesets used to 1.0.1. See https://github.com/Azure/azure-sdk-tools/issues/6071",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.0.1-update-core-to-1.0.1_2023-05-01.json
+++ b/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.0.1-update-core-to-1.0.1_2023-05-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator",
-      "comment": "affix rulesets used to 1.0.1. See https://github.com/Azure/azure-sdk-tools/issues/6071",
+      "comment": "affix rulesets used to 1.0.1 and update core to 1.0.1. See https://github.com/Azure/azure-sdk-tools/issues/6071",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.0.1_2023-05-01.json
+++ b/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.0.1_2023-05-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator",
+      "comment": "affix rulesets used to 1.0.1. See https://github.com/Azure/azure-sdk-tools/issues/6071",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator"
+}

--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -64,7 +64,7 @@
     "@stoplight/types": "^13.5.0",
     "dependency-graph": "^0.11.0",
     "@microsoft.azure/openapi-validator-core": "~1.0.0",
-    "@microsoft.azure/openapi-validator-rulesets": "~1.0.1",
+    "@microsoft.azure/openapi-validator-rulesets": "1.0.1",
     "@azure-tools/openapi": "^3.3.0",
     "fs": "^0.0.1-security",
     "js-yaml": "^3.14.0",

--- a/packages/azure-openapi-validator/core/package.json
+++ b/packages/azure-openapi-validator/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
In preparation to deploy [`@microsoft.azure/openapi-validator`](https://www.npmjs.com/package/@microsoft.azure/openapi-validator?activeTab=versions) `v2.0.1`, affix ruleset used to `1.0.1` and update [`@microsoft.azure/openapi-validator-core`](https://www.npmjs.com/package/@microsoft.azure/openapi-validator-core?activeTab=versions) from `1.0.0` to `1.0.1`.

This PR is step `1.1` from the [deployment plan](https://github.com/Azure/azure-sdk-tools/issues/6071#issuecomment-1529570291) of:
- https://github.com/Azure/azure-sdk-tools/issues/6071
