### PR TITLE
Update used ruleset from `1.0.1` to `1.1.0`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,22 @@
 # Changelog
 
+## What's New (05/03/2023)
+
+Continuing the work from 05/02/2023, updated the `@microsoft.azure/openapi-validator`
+dependency on  `@microsoft.azure/openapi-validator-rulesets` from `1.0.1` to `1.1.0`,
+As a result, updated the package version from `2.0.1` to `2.1.0`.
+in preparation to publish few last months of changes to the ruleset.
+
+For details, see:  
+  Deploy pending azure-openapi-validator (LintDiff) changes from staging to prod #6071
+  https://github.com/Azure/azure-sdk-tools/issues/6071
+
 ## What's New (05/02/2023)
 
 Continuing the work from 05/01/2023, updated the `@microsoft.azure/openapi-validator-rulesets` to `1.1.0`
 in preparation to publish few last months of changes to the ruleset.
 
-Also ran "rush update", "rush build", and commited the resulting changes.
+Also committed pending changes from "rush build".
 
 For details, see:  
   Deploy pending azure-openapi-validator (LintDiff) changes from staging to prod #6071

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## What's New (05/03/2023)
 
 Continuing the work from 05/02/2023, updated the `@microsoft.azure/openapi-validator`
-dependency on  `@microsoft.azure/openapi-validator-rulesets` from `1.0.1` to `1.1.0`,
+dependency on `@microsoft.azure/openapi-validator-rulesets` from `1.0.1` to `1.1.0`,
 As a result, updated the package version from `2.0.1` to `2.1.0`.
 in preparation to publish few last months of changes to the ruleset.
 

--- a/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.1.0_2023-05-03.json
+++ b/common/changes/@microsoft.azure/openapi-validator/affix-rulesets-to-1.1.0_2023-05-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator",
+      "comment": "Affix rulesets used to 1.1.0. See https://github.com/Azure/azure-sdk-tools/issues/6071",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator"
+}

--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Azure OpenAPI Validator",
   "main": "./dist/index.js",
   "scripts": {
@@ -64,7 +64,7 @@
     "@stoplight/types": "^13.5.0",
     "dependency-graph": "^0.11.0",
     "@microsoft.azure/openapi-validator-core": "~1.0.0",
-    "@microsoft.azure/openapi-validator-rulesets": "1.0.1",
+    "@microsoft.azure/openapi-validator-rulesets": "1.1.0",
     "@azure-tools/openapi": "^3.3.0",
     "fs": "^0.0.1-security",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
A follow-up to:
- https://github.com/Azure/azure-openapi-validator/pull/496

This PR does step 3.1 from:
- https://github.com/Azure/azure-sdk-tools/issues/6071#issuecomment-1529570291
