### PR TITLE
Fix RPC_Patch_V1_02

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/rmanda-fix_rpc_patch_v1_02_2023-05-12-05-42.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/rmanda-fix_rpc_patch_v1_02_2023-05-12-05-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "fixing rpc_patch_v1_02",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/patch-sku-property.md
+++ b/docs/patch-sku-property.md
@@ -14,7 +14,7 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-The patch operation body parameter schema should contains property 'sku'.
+The patch operation body parameter schema should contain property 'sku'.
 
 ## Description
 

--- a/docs/un-supported-patch-properties.md
+++ b/docs/un-supported-patch-properties.md
@@ -14,7 +14,7 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-The patch operation body parameter schema should not contains property {propertyName}.
+The patch operation body parameter schema should not contain top level "id", "name", "type", "location" as writable properties. This is because these properties are expected to be either readOnly or immutable.
 
 ## Description
 
@@ -30,4 +30,4 @@ July 07, 2022
 
 ## How to fix the violation
 
-Considering removing the name, location, or type in the patch request body.
+Consider either removing the top level properties - id, name and type, from the patch request body or mark them as readOnly. For the top level location property for tracked resources, consider either removing it from the request body of the Patch operation or mark it as immutable using the x-ms-mutability property and values as "create" and "read".

--- a/docs/un-supported-patch-properties.md
+++ b/docs/un-supported-patch-properties.md
@@ -14,7 +14,7 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-The patch operation body parameter schema should not contain top level "id", "name", "type", "location" as writable properties. This is because these properties are expected to be either readOnly or immutable.
+The patch operation body parameter schema should not contain top level "id", "name", "type", "location" as writable properties. This is because these properties are not patchable. To fix this, either remove the offending properties from the request payload of the Patch operation, or mark them as readOnly or immutable.
 
 ## Description
 

--- a/docs/un-supported-patch-properties.md
+++ b/docs/un-supported-patch-properties.md
@@ -30,4 +30,4 @@ July 07, 2022
 
 ## How to fix the violation
 
-Consider either removing the top level properties - id, name and type, from the patch request body or mark them as readOnly. For the top level location property for tracked resources, consider either removing it from the request body of the Patch operation or mark it as immutable using the x-ms-mutability property and values as "create" and "read".
+Consider either removing the top-level properties - "id", "name" and "type", from the patch request body parameter schema, or mark them as readOnly. For the top-level "location" property (that is specified for tracked resources), consider either removing it from the request body of the Patch operation or mark it as immutable using the x-ms-mutability property and values as "create" and "read".

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2395,20 +2395,20 @@ const validatePatchBodyParamProperties = createRulesetFunction({
                 var _a;
                 const property = (_a = getProperties(bodyParameter)) === null || _a === void 0 ? void 0 : _a[p];
                 if (property) {
-                    let isPropertyBoolean = false;
+                    let isPropertyReadOnly = false;
                     let isPropertyImmutable = false;
                     if (property["readOnly"] && property["readOnly"] === true) {
-                        isPropertyBoolean = true;
+                        isPropertyReadOnly = true;
                     }
                     if (property["x-ms-mutability"] && Array.isArray(property["x-ms-mutability"])) {
-                        const schemeArray = property["x-ms-mutability"];
-                        if (!schemeArray.includes("update")) {
+                        const schemaArray = property["x-ms-mutability"];
+                        if (!schemaArray.includes("update")) {
                             isPropertyImmutable = true;
                         }
                     }
-                    if (!isPropertyBoolean && !isPropertyImmutable) {
+                    if (!(isPropertyReadOnly || isPropertyImmutable)) {
                         errors.push({
-                            message: `The patch operation body parameter schema should not contain property ${p}.`,
+                            message: `Mark the top level property - ${p} specified in the patch operation body as readOnly or immutable. These properties are not patchable.`,
                             path: [...path, "parameters", index],
                         });
                     }
@@ -2634,7 +2634,7 @@ const ruleset = {
             then: {
                 function: validatePatchBodyParamProperties,
                 functionOptions: {
-                    shouldNot: ["name", "type", "location"],
+                    shouldNot: ["id", "name", "type", "location"],
                 },
             },
         },

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2393,11 +2393,25 @@ const validatePatchBodyParamProperties = createRulesetFunction({
         if (_opts.shouldNot) {
             _opts.shouldNot.forEach((p) => {
                 var _a;
-                if ((_a = getProperties(bodyParameter)) === null || _a === void 0 ? void 0 : _a[p]) {
-                    errors.push({
-                        message: `The patch operation body parameter schema should not contains property ${p}.`,
-                        path: [...path, "parameters", index],
-                    });
+                const property = (_a = getProperties(bodyParameter)) === null || _a === void 0 ? void 0 : _a[p];
+                if (property) {
+                    var isPropertyBoolean = false;
+                    var isPropertyImmutable = false;
+                    if (property["readOnly"] && property["readOnly"] === true) {
+                        isPropertyBoolean = true;
+                    }
+                    if (property["x-ms-mutability"] && Array.isArray(property["x-ms-mutability"])) {
+                        const schemeArray = property["x-ms-mutability"];
+                        if (!schemeArray.includes("update")) {
+                            isPropertyImmutable = true;
+                        }
+                    }
+                    if (!isPropertyBoolean && !isPropertyImmutable) {
+                        errors.push({
+                            message: `The patch operation body parameter schema should not contains property ${p}.`,
+                            path: [...path, "parameters", index],
+                        });
+                    }
                 }
             });
         }

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2384,7 +2384,7 @@ const validatePatchBodyParamProperties = createRulesetFunction({
                 var _a, _b;
                 if (!((_a = getProperties(bodyParameter)) === null || _a === void 0 ? void 0 : _a[p]) && ((_b = getProperties(responseSchema)) === null || _b === void 0 ? void 0 : _b[p])) {
                     errors.push({
-                        message: `The patch operation body parameter schema should contains property '${p}'.`,
+                        message: `The patch operation body parameter schema should contain property '${p}'.`,
                         path: [...path, "parameters", index],
                     });
                 }
@@ -2395,8 +2395,8 @@ const validatePatchBodyParamProperties = createRulesetFunction({
                 var _a;
                 const property = (_a = getProperties(bodyParameter)) === null || _a === void 0 ? void 0 : _a[p];
                 if (property) {
-                    var isPropertyBoolean = false;
-                    var isPropertyImmutable = false;
+                    let isPropertyBoolean = false;
+                    let isPropertyImmutable = false;
                     if (property["readOnly"] && property["readOnly"] === true) {
                         isPropertyBoolean = true;
                     }
@@ -2408,7 +2408,7 @@ const validatePatchBodyParamProperties = createRulesetFunction({
                     }
                     if (!isPropertyBoolean && !isPropertyImmutable) {
                         errors.push({
-                            message: `The patch operation body parameter schema should not contains property ${p}.`,
+                            message: `The patch operation body parameter schema should not contain property ${p}.`,
                             path: [...path, "parameters", index],
                         });
                     }

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2408,7 +2408,7 @@ const validatePatchBodyParamProperties = createRulesetFunction({
                     }
                     if (!(isPropertyReadOnly || isPropertyImmutable)) {
                         errors.push({
-                            message: `Mark the top level property - ${p} specified in the patch operation body as readOnly or immutable. These properties are not patchable.`,
+                            message: `Mark the top-level property "${p}", specified in the patch operation body, as readOnly or immutable. You could also choose to remove it from the request payload of the Patch operation. These properties are not patchable.`,
                             path: [...path, "parameters", index],
                         });
                     }

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -298,7 +298,7 @@ const ruleset: any = {
       then: {
         function: validatePatchBodyParamProperties,
         functionOptions: {
-          shouldNot: ["name", "type", "location"],
+          shouldNot: ["id", "name", "type", "location"],
         },
       },
     },

--- a/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
+++ b/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
@@ -56,26 +56,23 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
         _opts.shouldNot.forEach((p: string) => {
           const property = getProperties(bodyParameter)?.[p];
           if (property) {
-            let isPropertyBoolean = false;
+            let isPropertyReadOnly = false;
             let isPropertyImmutable = false;
 
-            if (property["readOnly"] && property["readOnly"] === true)
-            {
-              isPropertyBoolean = true;
+            if (property["readOnly"] && property["readOnly"] === true) {
+              isPropertyReadOnly = true;
             }
 
             if (property["x-ms-mutability"] && Array.isArray(property["x-ms-mutability"])) {
-                const schemeArray = property["x-ms-mutability"];
-                if (!schemeArray.includes("update"))
-                {
-                    isPropertyImmutable = true;
-                }
+              const schemaArray = property["x-ms-mutability"];
+              if (!schemaArray.includes("update")) {
+                isPropertyImmutable = true;
+              }
             }
 
-            if (!isPropertyBoolean && !isPropertyImmutable)
-            {
+            if (!(isPropertyReadOnly || isPropertyImmutable)) {
               errors.push({
-                message: `The patch operation body parameter schema should not contain property ${p}.`,
+                message: `Mark the top level property - ${p} specified in the patch operation body as readOnly or immutable. These properties are not patchable.`,
                 path: [...path, "parameters", index],
               })
             }

--- a/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
+++ b/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
@@ -46,7 +46,7 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
         _opts.should.forEach((p: string) => {
           if (!getProperties(bodyParameter)?.[p] && getProperties(responseSchema)?.[p]) {
             errors.push({
-              message: `The patch operation body parameter schema should contains property '${p}'.`,
+              message: `The patch operation body parameter schema should contain property '${p}'.`,
               path: [...path, "parameters", index],
             })
           }
@@ -56,8 +56,8 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
         _opts.shouldNot.forEach((p: string) => {
           const property = getProperties(bodyParameter)?.[p];
           if (property) {
-            var isPropertyBoolean = false;
-            var isPropertyImmutable = false;
+            let isPropertyBoolean = false;
+            let isPropertyImmutable = false;
 
             if (property["readOnly"] && property["readOnly"] === true)
             {
@@ -75,7 +75,7 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
             if (!isPropertyBoolean && !isPropertyImmutable)
             {
               errors.push({
-                message: `The patch operation body parameter schema should not contains property ${p}.`,
+                message: `The patch operation body parameter schema should not contain property ${p}.`,
                 path: [...path, "parameters", index],
               })
             }

--- a/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
+++ b/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
@@ -54,11 +54,31 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
       }
       if (_opts.shouldNot) {
         _opts.shouldNot.forEach((p: string) => {
-          if (getProperties(bodyParameter)?.[p]) {
-            errors.push({
-              message: `The patch operation body parameter schema should not contains property ${p}.`,
-              path: [...path, "parameters", index],
-            })
+          const property = getProperties(bodyParameter)?.[p];
+          if (property) {
+            var isPropertyBoolean = false;
+            var isPropertyImmutable = false;
+
+            if (property["readOnly"] && property["readOnly"] === true)
+            {
+              isPropertyBoolean = true;
+            }
+
+            if (property["x-ms-mutability"] && Array.isArray(property["x-ms-mutability"])) {
+                const schemeArray = property["x-ms-mutability"];
+                if (!schemeArray.includes("update"))
+                {
+                    isPropertyImmutable = true;
+                }
+            }
+
+            if (!isPropertyBoolean && !isPropertyImmutable)
+            {
+              errors.push({
+                message: `The patch operation body parameter schema should not contains property ${p}.`,
+                path: [...path, "parameters", index],
+              })
+            }
           }
         })
       }

--- a/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
+++ b/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
@@ -54,25 +54,25 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
       }
       if (_opts.shouldNot) {
         _opts.shouldNot.forEach((p: string) => {
-          const property = getProperties(bodyParameter)?.[p];
+          const property = getProperties(bodyParameter)?.[p]
           if (property) {
-            let isPropertyReadOnly = false;
-            let isPropertyImmutable = false;
+            let isPropertyReadOnly = false
+            let isPropertyImmutable = false
 
             if (property["readOnly"] && property["readOnly"] === true) {
-              isPropertyReadOnly = true;
+              isPropertyReadOnly = true
             }
 
             if (property["x-ms-mutability"] && Array.isArray(property["x-ms-mutability"])) {
-              const schemaArray = property["x-ms-mutability"];
+              const schemaArray = property["x-ms-mutability"]
               if (!schemaArray.includes("update")) {
-                isPropertyImmutable = true;
+                isPropertyImmutable = true
               }
             }
 
             if (!(isPropertyReadOnly || isPropertyImmutable)) {
               errors.push({
-                message: `Mark the top level property - ${p} specified in the patch operation body as readOnly or immutable. These properties are not patchable.`,
+                message: `Mark the top-level property "${p}", specified in the patch operation body, as readOnly or immutable. You could also choose to remove it from the request payload of the Patch operation. These properties are not patchable.`,
                 path: [...path, "parameters", index],
               })
             }

--- a/packages/rulesets/src/spectral/test/patch-identity-property.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-identity-property.test.ts
@@ -113,7 +113,7 @@ test("PatchIdentityProperty should find errors", () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("The patch operation body parameter schema should contains property 'identity'.")
+    expect(results[0].message).toContain("The patch operation body parameter schema should contain property 'identity'.")
   })
 })
 

--- a/packages/rulesets/src/spectral/test/patch-not-suport-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-not-suport-properties.test.ts
@@ -85,7 +85,7 @@ test("UnSupportedPatchProperties should find errors when name is specified but n
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("Mark the top level property - name specified in the patch operation body as readOnly or immutable. These properties are not patchable.")
+    expect(results[0].message).toContain("Mark the top-level property \"name\", specified in the patch operation body, as readOnly or immutable. You could also choose to remove it from the request payload of the Patch operation. These properties are not patchable.")
   })
 })
 
@@ -175,7 +175,7 @@ test("UnSupportedPatchProperties should find errors when the top level propertie
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("Mark the top level property - location specified in the patch operation body as readOnly or immutable. These properties are not patchable.")
+    expect(results[0].message).toContain("Mark the top-level property \"location\", specified in the patch operation body, as readOnly or immutable. You could also choose to remove it from the request payload of the Patch operation. These properties are not patchable.")
   })
 })
 

--- a/packages/rulesets/src/spectral/test/patch-not-suport-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-not-suport-properties.test.ts
@@ -85,11 +85,11 @@ test("UnSupportedPatchProperties should find errors", () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("The patch operation body parameter schema should not contains property name.")
+    expect(results[0].message).toContain("The patch operation body parameter schema should not contain property name.")
   })
 })
 
-test("UnSupportedPatchProperties should find errors when the top level properties are mentioned with x-ms-mutability (create, update, read) ", () => {
+test("UnSupportedPatchProperties should find errors when the top level properties are mentioned with x-ms-mutability (create, update, read)", () => {
   const oasDoc = {
     swagger: "2.0",
     paths: {
@@ -175,11 +175,11 @@ test("UnSupportedPatchProperties should find errors when the top level propertie
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("The patch operation body parameter schema should not contains property location.")
+    expect(results[0].message).toContain("The patch operation body parameter schema should not contain property location.")
   })
 })
 
-test("UnSupportedPatchProperties should find no errors when the top level properties are mentioned as readOnly or with x-ms-mutability (create, read) ", () => {
+test("UnSupportedPatchProperties should find no errors when the top level properties are mentioned as readOnly or with x-ms-mutability (create, read)", () => {
   const oasDoc = {
     swagger: "2.0",
     paths: {

--- a/packages/rulesets/src/spectral/test/patch-not-suport-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-not-suport-properties.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
   return linter
 })
 
-test("UnSupportedPatchProperties should find errors", () => {
+test("UnSupportedPatchProperties should find errors when name is specified but not marked readOnly", () => {
   const oasDoc = {
     swagger: "2.0",
     paths: {
@@ -85,7 +85,7 @@ test("UnSupportedPatchProperties should find errors", () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("The patch operation body parameter schema should not contain property name.")
+    expect(results[0].message).toContain("Mark the top level property - name specified in the patch operation body as readOnly or immutable. These properties are not patchable.")
   })
 })
 
@@ -175,7 +175,7 @@ test("UnSupportedPatchProperties should find errors when the top level propertie
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("The patch operation body parameter schema should not contain property location.")
+    expect(results[0].message).toContain("Mark the top level property - location specified in the patch operation body as readOnly or immutable. These properties are not patchable.")
   })
 })
 
@@ -266,7 +266,106 @@ test("UnSupportedPatchProperties should find no errors when the top level proper
   })
 })
 
-test("UnSupportedPatchProperties should find no errors", () => {
+test("UnSupportedPatchProperties should find no errors when the top level properties are mentioned as readOnly or with x-ms-mutability (create, read) and some other deeply nested properties with the same name are writable", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/foo": {
+        patch: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Update",
+          description: "Test Description",
+          parameters: [
+            {
+              name: "foo_patch",
+              in: "body",
+              schema: {
+                $ref: "#/definitions/FooRequestParams",
+              },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Success",
+              schema: {
+                $ref: "#/definitions/FooResource",
+              },
+            },
+          },
+        },
+      },
+    },
+    definitions: {
+      FooRequestParams: {
+        allOf: [
+          {
+            $ref: "#/definitions/FooResource",
+          },
+        ],
+      },
+      FooProps: {
+        properties: {
+          name: {
+            type: "string"
+          },
+        },
+      },
+      Resource: {
+        "x-ms-azure-resource": true,
+        description: "Test Description",
+        properties: {
+          id: {
+            type: "string",
+            readOnly: true,
+          },
+          name: {
+            type: "string",
+            readOnly: true,
+          },
+          type: {
+            type: "string",
+            readOnly: true,
+          },
+          location: {
+            type: "string",
+            "x-ms-mutability": [
+              "read",
+              "create"
+            ],
+            "description": "The geo-location where the resource lives"            
+          },
+        },
+      },
+      FooResource: {
+        "x-ms-azure-resource": true,
+        allOf: [{ $ref: "#/definitions/Resource" }],
+        properties: {
+          properties: {
+            type: "object",
+            $ref: "#/definitions/FooResourceProperties",
+          }          
+        },
+      },
+      FooResourceProperties: {
+        description: "Properties def",
+        properties: {
+          provisioningState: {
+            type: "string",
+            enum: ["Creating", "Canceled", "Deleting", "Failed"],
+          },
+          name: {
+            type: "string"
+          }
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("UnSupportedPatchProperties should find no errors - variation without the location property", () => {
   const oasDoc = {
     swagger: "2.0",
     paths: {

--- a/packages/rulesets/src/spectral/test/patch-suport-sku.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-suport-sku.test.ts
@@ -106,7 +106,7 @@ test("PatchSkuProperty should find errors", () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0")
-    expect(results[0].message).toContain("The patch operation body parameter schema should contains property 'sku'.")
+    expect(results[0].message).toContain("The patch operation body parameter schema should contain property 'sku'.")
   })
 })
 


### PR DESCRIPTION
The rule RPC-Patch_V1_02 is to check if the top-level properties like name, type, location are not mentioned in the request body of a Patch operation. The exception to this rule is that it is ok for these properties to be specified as long as they are appropriately mentioned either as readOnly or immutable properties.

The earlier implementation of this rule did not take this exception into account and the current PR addresses this gap. The reason it is ok for readOnly and immutable properties to be specified in the payload is because the service is expected to treat these as pass thru as long as the values captured in the service are the same as the values being passed in with the payload.