### PR TITLE
Unpin used ruleset; change diagnostic log severity; major update to docs

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,4 +1,9 @@
 {
+    // MD004 - Unordered list style
+    // https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md
+    // Disabled because it warns on TOC generated with
+    // https://ecotrust-canada.github.io/markdown-toc/
+    "MD004": false,
     // MD013 - Line length
     // https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
     "MD013": { "line_length": 120, "code_blocks": false, "headings": false, "tables": false },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,8 @@
   "typescript.tsdk": "./common/temp/node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "cSpell.words": [
+    "ruleset"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
     "packages/rulesets/spectral/functions/*.js":false,
   },
   "[markdown]": {
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.formatOnPaste": true,
     "editor.insertSpaces": true,
     "editor.tabSize": 2,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,34 @@
+# Table of Contents
+
+- [Contributing](#contributing)
+- [Prerequisites to build locally](#prerequisites-to-build-locally)
+- [How to prepare for a PR submission after you made changes locally](#how-to-prepare-for-a-pr-submission-after-you-made-changes-locally)
+- [How to deploy your changes](#how-to-deploy-your-changes)
+  * [Deploy to Staging LintDiff](#deploy-to-staging-lintdiff)
+  * [Deploy to Prod LintDiff](#deploy-to-prod-lintdiff)
+- [How to run LintDiff locally](#how-to-run-lintdiff-locally)
+  * [Setup](#setup)
+  * [Execute your local LintDiff code](#execute-your-local-lintdiff-code)
+  * [Execute locally LintDiff version published to npm](#execute-locally-lintdiff-version-published-to-npm)
+- [How to disable or enable existing Spectral rules](#how-to-disable-or-enable-existing-spectral-rules)
+- [Installing NPM dependencies](#installing-npm-dependencies)
+- [How to test](#how-to-test)
+- [How to write a new validation rule using typescript](#how-to-write-a-new-validation-rule-using-typescript)
+  * [Spectral rule](#spectral-rule)
+  * [Native rule](#native-rule)
+  * [Rule properties](#rule-properties)
+- [How to run regression test](#how-to-run-regression-test)
+- [How to refresh the index of rules documentation](#how-to-refresh-the-index-of-rules-documentation)
+- [How to use the Spectral ruleset](#how-to-use-the-spectral-ruleset)
+  * [Dependencies](#dependencies)
+  * [Install Spectral](#install-spectral)
+  * [Usage](#usage)
+  * [Example](#example)
+  * [Using the Spectral VSCode extension](#using-the-spectral-vscode-extension)
+- [Appendix](#appendix)
+  * [Appendix for `Execute locally LintDiff version published to npm`](#appendix-for--execute-locally-lintdiff-version-published-to-npm-)
+
+
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
@@ -333,7 +364,7 @@ In the Problems panel you can filter to show or hide errors, warnings, or infos.
 
 # Appendix
 
-## Appendix for `Execute locally LintDiff version to npm`
+## Appendix for `Execute locally LintDiff version published to npm`
 
 This command:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 - [How to deploy your changes](#how-to-deploy-your-changes)
   * [Deploy to Staging LintDiff](#deploy-to-staging-lintdiff)
   * [Deploy to Prod LintDiff](#deploy-to-prod-lintdiff)
-  * [Verification of the deployed changes](#verification-of-the-deployed-changes)
+  * [Verify the deployed changes](#verify-the-deployed-changes)
 - [How to run LintDiff locally](#how-to-run-lintdiff-locally)
   * [Setup](#setup)
   * [Execute your local LintDiff code](#execute-your-local-lintdiff-code)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@
   * [Example](#example)
   * [Using the Spectral VSCode extension](#using-the-spectral-vscode-extension)
 - [Appendix](#appendix)
-  * [Appendix for `Execute locally LintDiff version published to npm`](#appendix-for--execute-locally-lintdiff-version-published-to-npm-)
+  * [Appendix for `Execute locally LintDiff version published to npm`](#appendix-for-execute-locally-lintdiff-version-published-to-npm)
 
 
 # Contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ You are about to submit your PR, but you want to ensure the changes in your PR w
 
 ## Deploy to Staging LintDiff
 
-If you want your changes to be deployed only to the [staging pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=3268)
+If you want your changes to be deployed only to the [Staging pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=3268)
 and hence Staging LintDiff, you don't need to change anything in your PR.
 
 Once your PR is merged, you just need to verify the [Staging release](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=108) with your changes succeeded.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,6 @@
 - [Appendix](#appendix)
   * [Appendix for `Execute locally LintDiff version published to npm`](#appendix-for-execute-locally-lintdiff-version-published-to-npm)
 
-
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ If you want your changes to be deployed to [production pipeline](https://dev.azu
   - Note that sometimes the npm release may report failure even when it succeeded. This is because sometimes it tries to publish package twice and succeeds only on the first time. You can verify your updated npm packages were published by reviewing your
   version is on npm. See [README `packages` section](https://github.com/Azure/azure-openapi-validator#packages). You can also look at the release build log.
 
-## Verification of the deployed changes
+## Verify the deployed changes
 
 If the changes you deployed include changes to the Spectral ruleset, you can verify the changes got deployed by following
 the guidance given in `How to verify which Spectral rules are running in Production and Staging LintDiff`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
 
 ## Setup
 
-1. Ensure you meet the [`How to prepare for a PR submission after you made changes locally`](#how-to-prepare-for-a-pr-submission-after-you-made-changes-locally) **up to and including** `rush build`.
+1. Ensure you meet the [`How to prepare for a PR submission after you made changes locally`](#how-to-prepare-for-a-pr-submission-after-you-made-changes-locally) requirements **up to and including** `rush build`.
 1. [Install AutoRest using npm](https://github.com/Azure/autorest/blob/main/docs/install/readme.md):
    ```bash
    # Depending on your configuration you may need to be elevated or root to run this. (on OSX/Linux use 'sudo' )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,13 @@
 - [How to deploy your changes](#how-to-deploy-your-changes)
   * [Deploy to Staging LintDiff](#deploy-to-staging-lintdiff)
   * [Deploy to Prod LintDiff](#deploy-to-prod-lintdiff)
+  * [Verification of the deployed changes](#verification-of-the-deployed-changes)
 - [How to run LintDiff locally](#how-to-run-lintdiff-locally)
   * [Setup](#setup)
   * [Execute your local LintDiff code](#execute-your-local-lintdiff-code)
   * [Execute locally LintDiff version published to npm](#execute-locally-lintdiff-version-published-to-npm)
 - [How to disable or enable existing Spectral rules](#how-to-disable-or-enable-existing-spectral-rules)
+- [How to verify which Spectral rules are running in Production and Staging LintDiff](#how-to-verify-which-spectral-rules-are-running-in-production-and-staging-lintdiff)
 - [Installing NPM dependencies](#installing-npm-dependencies)
 - [How to test](#how-to-test)
 - [How to write a new validation rule using typescript](#how-to-write-a-new-validation-rule-using-typescript)
@@ -109,6 +111,11 @@ If you want your changes to be deployed to [production pipeline](https://dev.azu
   - Note that sometimes the npm release may report failure even when it succeeded. This is because sometimes it tries to publish package twice and succeeds only on the first time. You can verify your updated npm packages were published by reviewing your
   version is on npm. See [README `packages` section](https://github.com/Azure/azure-openapi-validator#packages). You can also look at the release build log.
 
+## Verification of the deployed changes
+
+If the changes you deployed include changes to the Spectral ruleset, you can verify the changes got deployed by following
+the guidance given in `How to verify which Spectral rules are running in Production and Staging LintDiff`.
+
 # How to run LintDiff locally
 
 Instructions in this section use an example that assumes you are trying to locally reproduce a LintDiff failure
@@ -176,6 +183,12 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
   - For an example of 3 rules being disabled, see [this file diff](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-4c1382203db84bcd9df61a5bbf90823d0e1f39a833e8eaa1a5be96ca4a4e9b61).
 - Follow the instructions given in the `How to deploy your changes` section.
 
+# How to verify which Spectral rules are running in Production and Staging LintDiff
+
+You can look at the relevant build logs, as they output list of running Spectral rules, and if they are disabled.
+
+- An example for [Production LintDiff run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2773189&view=logs&j=0574a2a6-2d0a-5ec6-40e4-4c6e2f70bea2&t=80c3e782-49f0-5d1c-70dd-cbee57bdd0c7&l=88).
+- An example for [Staging LintDiff run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2773190&view=logs&j=688669d0-441c-57c3-cf6d-f89a22ccfa5d&t=b91b1e88-b042-5e18-36d8-34e4fb3a9b3b&l=89).
 
 # Installing NPM dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,25 +6,43 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 
 # Prerequisites to build locally
 
-1. Install `Node.js`, version 14.x or higher. This will also install `npm`. [Instructions for Windows](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#os-x-or-windows-node-installers). Then [verify](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#checking-your-version-of-npm-and-nodejs) the installation.
-2. Install [@Microsoft/Rush](https://rushjs.io/), version 5.x or higher:
+1. Install [nvm] ([nvm for Windows]), a tool to manage `Node.js` versions.
+2. Restart your terminal so that `nvm` command is recognized.
+3. Using `nvm`, install `Node.js` version `12.22.12`. This is the version used by the [PR CI pipeline] to build `LintDiff`.
+   - `nvm install 12.22.12`
+   - `nvm use 12.22.12`
+   - `node --version`, to confirm.
+4. Note that installing `Node.js` will also install `npm`.
+5. Install [@Microsoft/Rush](https://rushjs.io/). Note that the [PR CI pipeline] uses version `5.62.1`, so you might want to switch to it in case you run into unexpected issues later on.
    ```bash
+   # Install latest rush, globally
    npm install -g @microsoft/rush
+
+   # OR Install specific version, to the local node_modules folder
+   cd "this_repo_local_clone_dir"
+   npm install @microsoft/rush@5.26.1
    ```
+
+[nvm]: https://github.com/nvm-sh/nvm#installing-and-updating
+[nvm for Windows]: https://github.com/coreybutler/nvm-windows
+[PR CI pipeline]: https://dev.azure.com/azure-sdk/public/_build?definitionId=5261&_a=summary
 
 # How to prepare for a PR submission after you made changes locally
 
+We will be replicating locally what [PR CI pipeline] is doing, and more.
+
+1. Ensure you have fulfilled `Prerequisites to build locally`.
 1. Ensure your local clone branch is up-to-date with `main`. If you are using a fork, ensure your local fork branch is based on origin repo `main`.
-2. Run `rush update` to ensure all the required modules are installed.
-3. Run `rush build` to regenerate relevant files that need to be checked-in.
-4. Run `rush lint`. It must pass. If it doesn't, you can debug with `rush lint --verbose`.
-5. Run `rush test` to run the unit tests. They should all pass.
-6. If you changed the ruleset, run `rush regen-ruleindex` to update contents of `docs/rules.md`.
+1. Run `rush update` to ensure all the required modules are installed.
+1. Run `rush build` to regenerate relevant files that need to be checked-in.
+1. Run `rush lint`. It must pass. If it doesn't, you can debug with `rush lint --verbose`.
+1. Run `rush test` to run the unit tests. They should all pass.
+1. If you changed the ruleset, run `rush regen-ruleindex` to update contents of `docs/rules.md`.
    For details, see `How to refresh the index of rules documentation`.
-7. Run `rush change` to generate changelog. You will need to follow the interactive prompts.
+1. Run `rush change` to generate changelog. You will need to follow the interactive prompts.
    You can edit the added files later. If you don't add the right entries, the CI build will fail.
-8. If the change is siginficant, you might consider manually adding appropriate entry to `changelog.md`.
-9. You are now ready to submit your PR.
+1. If the change is significant, you might consider manually adding appropriate entry to `changelog.md`.
+1. You are now ready to submit your PR.
 
 # Installing NPM dependencies
 
@@ -182,10 +200,10 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
    - `git clone https://github.com/Azure/azure-rest-api-specs-pr.git`
    - `git checkout containerservice/official/fleet-api-release`
 4. `cd repos/azure-openapi-validator` // Here we assume this is your local clone of LintDiff.
+5. Ensure your local LintDiff is prepped for execution. See `How to prepare for a PR submission after you made changes locally`.
 
 ## Execute your local LintDiff code
 
-5. Ensure your local LintDiff is prepped for execution. See `How to prepare for a PR submission after you made changes locally`.
 6. Execute following command:
 
    ```bash
@@ -206,7 +224,7 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
 
 ## Execute locally LintDiff version published to npm
 
-5. Familiarize yourself with instructions for `Execute your local LintDiff code`. The only difference is that instead of passing `--use=./packages/azure-openapi-validator/autorest` you will pass `-use=@microsoft.azure/openapi-validator@<version-tag>` where you can obtain `<version-tag>` from [npm package @microsoft.azure/openapi-validator](https://www.npmjs.com/package/@microsoft.azure/openapi-validator?activeTab=versions).
+6. Familiarize yourself with instructions for `Execute your local LintDiff code`. The only difference is that instead of passing `--use=./packages/azure-openapi-validator/autorest` you will pass `-use=@microsoft.azure/openapi-validator@<version-tag>` where you can obtain `<version-tag>` from [npm package @microsoft.azure/openapi-validator](https://www.npmjs.com/package/@microsoft.azure/openapi-validator?activeTab=versions).
 
    Continuing our example for PR 12357, we can observe that version `2.0.1`, which as of this writing (5/5/2023) runs in production, produces only `warning | IgnoredPropertyNextToRef`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 
 A lot of the instructions below replicate what the [PR CI pipeline] is doing.
 
-1. Ensure you have fulfilled `Prerequisites to build locally`.
+1. Ensure you have fulfilled [`Prerequisites to build locally`](#prerequisites-to-build-locally).
 1. Ensure your local clone branch is based on an up-to-date `main` branch.
     - If you are using a fork, ensure your fork `main` branch is up-to-date with
     the origin `main` branch and that your branch is based on your fork `main` branch.
@@ -81,13 +81,13 @@ A lot of the instructions below replicate what the [PR CI pipeline] is doing.
    You can edit the added files later. If you don't add the right entries, the CI build will fail.
 1. If the change is significant, you might consider manually adding appropriate entry to `changelog.md`.
 1. If you want for your changes to be deployed to production LintDiff, not only Staging LintDiff, follow the instructions
-  given in `How to deploy your changes`.
+  given in [`How to deploy your changes`](#how-to-deploy-your-changes).
 1. You are now ready to submit your PR.
-1. After your PR ise merged, most likely you will want to read `How to deploy your changes` to verify they got deployed.
+1. After your PR ise merged, most likely you will want to read [`How to deploy your changes`](#how-to-deploy-your-changes) to verify they got deployed.
 
 # How to deploy your changes
 
-Let's assume you followed most of the instructions given in `How to prepare for a PR submission after you made changes locally`.
+Let's assume you followed most of the instructions given in [`How to prepare for a PR submission after you made changes locally`](#how-to-prepare-for-a-pr-submission-after-you-made-changes-locally).
 You are about to submit your PR, but you want to ensure the changes in your PR will end up correctly deployed.
 
 ## Deploy to Staging LintDiff
@@ -108,7 +108,7 @@ If you want your changes to be deployed to [production pipeline](https://dev.azu
   - Do not increase the major version. Only patch or minor, as applicable. If your change justifies major version change,
   ensure the tool owner reviewed your PR.
 - Once your PR is merged and [relevant build](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1580&_a=summary) completed, approve an [npm release](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=80) from the build.
-  - Note that sometimes the npm release may report failure even when it succeeded. This is because sometimes it tries to publish package twice and succeeds only on the first time. You can verify your updated npm packages were published by reviewing your
+  - Note that sometimes the npm release may report failure even when it succeeded. This is because sometimes it tries to publish package twice and succeeds only on the first try. You can verify your updated npm packages were published by reviewing your
   version is on npm. See [README `packages` section](https://github.com/Azure/azure-openapi-validator#packages). You can also look at the release build log.
 
 ## Verify the deployed changes
@@ -123,7 +123,7 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
 
 ## Setup
 
-1. Ensure you meet the `How to prepare for a PR submission after you made changes locally` **up to and including** `rush build`.
+1. Ensure you meet the [`How to prepare for a PR submission after you made changes locally`](#how-to-prepare-for-a-pr-submission-after-you-made-changes-locally) **up to and including** `rush build`.
 1. [Install AutoRest using npm](https://github.com/Azure/autorest/blob/main/docs/install/readme.md):
    ```bash
    # Depending on your configuration you may need to be elevated or root to run this. (on OSX/Linux use 'sudo' )
@@ -181,7 +181,7 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
 
 - Set the Spectral rule severity to `off` to disable it. Revert that to enable it back.
   - For an example of 3 rules being disabled, see [this file diff](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-4c1382203db84bcd9df61a5bbf90823d0e1f39a833e8eaa1a5be96ca4a4e9b61).
-- Follow the instructions given in the `How to deploy your changes` section.
+- Follow the instructions given in the [`How to deploy your changes`](#how-to-deploy-your-changes) section.
 
 # How to verify which Spectral rules are running in Production and Staging LintDiff
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,36 @@ A lot of the instructions below replicate what the [PR CI pipeline] is doing.
 1. Run `rush change` to generate changelog. You will need to follow the interactive prompts.
    You can edit the added files later. If you don't add the right entries, the CI build will fail.
 1. If the change is significant, you might consider manually adding appropriate entry to `changelog.md`.
+1. If you want for your changes to be deployed to production LintDiff, not only Staging LintDiff, follow the instructions
+  given in `How to deploy your changes`.
 1. You are now ready to submit your PR.
+1. After your PR ise merged, most likely you will want to read `How to deploy your changes` to verify they got deployed.
 
+# How to deploy your changes
+
+Let's assume you followed most of the instructions given in `How to prepare for a PR submission after you made changes locally`.
+You are about to submit your PR, but you want to ensure the changes in your PR will end up correctly deployed.
+
+## Deploy to Staging LintDiff
+
+If you want your changes to be deployed only to the [staging pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=3268)
+and hence Staging LintDiff, you don't need to change anything in your PR.
+
+Once your PR is merged, you just need to verify the [Staging release](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=108) with your changes succeeded.
+It should trigger automatically, publishing new `beta` versions of relevant packages to npm.
+
+## Deploy to Prod LintDiff
+
+If you want your changes to be deployed to [production pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1736&_a=summary) and hence Production LintDiff, you need to do the following:
+
+- In the PR with your changes increase the version number of the packages you changed.
+  - [Here](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-cad0ec93b3ac24499b20ae58530a4c3e7f369bde5ba1250dea8cad8201e75c30) is an example version increase for the ruleset.
+  - And [here](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-359645f2d25015199598e139bc9b03c9fec5d5b1a4a0ae1f1e4f7a651675e6bf) for changes made to the  AutoRest extension.
+  - Do not increase the major version. Only patch or minor, as applicable. If your change justifies major version change,
+  ensure the tool owner reviewed your PR.
+- Once your PR is merged and [relevant build](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1580&_a=summary) completed, approve an [npm release](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=80) from the build.
+  - Note that sometimes the npm release may report failure even when it succeeded. This is because sometimes it tries to publish package twice and succeeds only on the first time. You can verify your updated npm packages were published by reviewing your
+  version is on npm. See [README `packages` section](https://github.com/Azure/azure-openapi-validator#packages). You can also look at the release build log.
 
 # How to run LintDiff locally
 
@@ -111,6 +139,13 @@ in one of the PRs submitted to [azure-rest-api-specs](https://github.com/Azure/a
    ```
 
    You can find example outputs of these commands in the `Appendix` section at the end of this document.
+
+# How to disable or enable existing Spectral rules
+
+- Set the Spectral rule severity to `off` to disable it. Revert that to enable it back.
+  - For an example of 3 rules being disabled, see [this file diff](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-4c1382203db84bcd9df61a5bbf90823d0e1f39a833e8eaa1a5be96ca4a4e9b61).
+- Follow the instructions given in the `How to deploy your changes` section.
+
 
 # Installing NPM dependencies
 

--- a/common/changes/@microsoft.azure/openapi-validator/assorted_fixes_2023-05-13-06-11.json
+++ b/common/changes/@microsoft.azure/openapi-validator/assorted_fixes_2023-05-13-06-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator",
+      "comment": "Unping used ruleset",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator"
+}

--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Azure OpenAPI Validator",
   "main": "./dist/index.js",
   "scripts": {
@@ -64,7 +64,7 @@
     "@stoplight/types": "^13.5.0",
     "dependency-graph": "^0.11.0",
     "@microsoft.azure/openapi-validator-core": "~1.0.0",
-    "@microsoft.azure/openapi-validator-rulesets": "1.1.1",
+    "@microsoft.azure/openapi-validator-rulesets": "^1.1.1",
     "@azure-tools/openapi": "^3.3.0",
     "fs": "^0.0.1-security",
     "js-yaml": "^3.14.0",

--- a/packages/azure-openapi-validator/autorest/src/openapi-validator-plugin-func.ts
+++ b/packages/azure-openapi-validator/autorest/src/openapi-validator-plugin-func.ts
@@ -30,7 +30,7 @@ export async function openapiValidatorPluginFunc(initiator: IAutoRestPluginIniti
     read: readFile,
   }
   initiator.Message({
-    Channel: "verbose",
+    Channel: "information",
     Text: `Validating '${files.join("\n")}'`,
   })
   try {

--- a/packages/azure-openapi-validator/autorest/src/spectral-plugin-func.ts
+++ b/packages/azure-openapi-validator/autorest/src/spectral-plugin-func.ts
@@ -94,7 +94,7 @@ function printRuleNames(initiator: IAutoRestPluginInitiator, ruleset: Ruleset, r
     const severity: DiagnosticSeverity = ruleset.rules[ruleName].severity
     const sevStr: string = Number(severity) == -1 ? "DISABLED" : DiagnosticSeverity[severity]
     initiator.Message({
-      Channel: sevStr == "DISABLED" ? "warning" : "information",
+      Channel: "information",
       Text: (sevStr == "DISABLED" ? "DISABLED " : "").concat(`Spectral rule, severity '${sevStr}': '${ruleName}'`),
     })
   }


### PR DESCRIPTION
The ruleset is now unpinned so that folks can update the ruleset package without having to publish new AutoRest extension package.

The diagnostic log level had to be changed from warning to information due to the changes explained here:
- https://devdiv.visualstudio.com/DevDiv/_git/openapi-alps/pullrequest/471367

The doc update elaborates on:
- how to prep a PR, 
- deploy changes in PR, 
- how to disable and enable a spectral rule,
- how to verify which spectral rules are running.

I also changed few formatter settings and generated table of contents with https://ecotrust-canada.github.io/markdown-toc/

