### PR TITLE
Check if the property of type object has definition or not

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-check-properties-type-object_2023-05-16-18-19.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-check-properties-type-object_2023-05-16-18-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Added rule to detect PropertiesTypeObjectNoDefinition (RPC-Policy-V1-03)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/properties-type-object-no-definition.md
+++ b/docs/properties-type-object-no-definition.md
@@ -1,0 +1,45 @@
+# PropertiesTypeObjectNoDefinition
+
+## Category
+
+ARM Error
+
+## Applies to
+
+ARM OpenAPI(swagger) specs
+
+## Related ARM Guideline Code
+
+- RPC-Policy-V1-03
+
+## Output Message
+
+Properties with type:object should have definition of a reference model
+
+## Description
+
+If Properties with type:object dont have a reference model defined, then the allowed types can only be primitive data types instead of type:object
+
+## CreatedAt
+
+April 18, 2023
+
+## LastModifiedAt
+
+May 16, 2023
+
+## How to fix the violation
+
+The "type:object" model is not defined in the payload.
+Define the reference model of the object or change the "type" to "primitive-data-type".
+The following would be invalid:
+
+```json
+...
+"properties": {
+    "info": {
+        "type": "object",
+    }
+}
+...
+```

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2418,6 +2418,21 @@ const withXmsResource = (putOperation, _opts, ctx) => {
     return errors;
 };
 
+const errorMessage = "If Properties with type:object dont have a reference model defined, then the allowed types can only be primitive data types.";
+const propertiesTypeObjectNoDefinition = (definitionObject, _opts, ctx) => {
+    if ((definitionObject === null || definitionObject === void 0 ? void 0 : definitionObject.type) === "") {
+        return [{ message: errorMessage, path: ctx.path }];
+    }
+    const valuess = Object.values(definitionObject);
+    for (const val of valuess) {
+        if (typeof val === "object")
+            return [];
+        else
+            continue;
+    }
+    return [{ message: errorMessage, path: ctx.path }];
+};
+
 const ruleset = {
     extends: [ruleset$1],
     rules: {
@@ -2608,6 +2623,17 @@ const ruleset = {
             given: "$[paths,'x-ms-paths']",
             then: {
                 function: ParametersInPointGet,
+            },
+        },
+        PropertiesTypeObjectNoDefinition: {
+            description: "If Properties with type:object dont have a reference model defined, then the allowed types can only be primitive data types.",
+            severity: "error",
+            message: "{{description}}",
+            resolved: true,
+            formats: [oas2],
+            given: "$.definitions..[?((@property === 'type' && @ ==='object' || @ ===''))]^",
+            then: {
+                function: propertiesTypeObjectNoDefinition,
             },
         },
         UnSupportedPatchProperties: {

--- a/packages/rulesets/src/native/legacyRules/NestedResourcesMustHaveListOperation.ts
+++ b/packages/rulesets/src/native/legacyRules/NestedResourcesMustHaveListOperation.ts
@@ -2,6 +2,7 @@ import { JsonPath, rules, MergeStates, OpenApiTypes } from "@microsoft.azure/ope
 
 import { ArmHelper } from "../utilities/arm-helper"
 
+// This function also covers RPC-Policy-V1-04
 export const NestedResourcesMustHaveListOperation = "NestedResourcesMustHaveListOperation"
 
 rules.push({

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -29,6 +29,7 @@ import { ParametersInPost } from "./functions/parameters-in-post"
 import pathBodyParameters from "./functions/patch-body-parameters"
 import { PatchResponseCode } from "./functions/patch-response-code"
 import pathSegmentCasing from "./functions/path-segment-casing"
+import { propertiesTypeObjectNoDefinition } from "./functions/properties-type-object-no-definition"
 import provisioningState from "./functions/provisioning-state"
 import { provisioningStateMustBeReadOnly } from "./functions/provisioning-state-must-be-read-only"
 import putGetPatchScehma from "./functions/put-get-patch-schema"
@@ -280,6 +281,20 @@ const ruleset: any = {
       given: "$[paths,'x-ms-paths']",
       then: {
         function: ParametersInPointGet,
+      },
+    },
+
+    // RPC Code: RPC-Policy-V1-03
+    PropertiesTypeObjectNoDefinition: {
+      description:
+        "If Properties with type:object dont have a reference model defined, then the allowed types can only be primitive data types.",
+      severity: "error",
+      message: "{{description}}",
+      resolved: true,
+      formats: [oas2],
+      given: "$.definitions..[?((@property === 'type' && @ ==='object' || @ ===''))]^",
+      then: {
+        function: propertiesTypeObjectNoDefinition,
       },
     },
 

--- a/packages/rulesets/src/spectral/functions/properties-type-object-no-definition.ts
+++ b/packages/rulesets/src/spectral/functions/properties-type-object-no-definition.ts
@@ -1,0 +1,15 @@
+// If a property is defined with `'type': 'object'`, it must also define an object body.
+// RPC Code: RPC-Policy-V1-03
+const errorMessage =
+  "If Properties with type:object dont have a reference model defined, then the allowed types can only be primitive data types."
+export const propertiesTypeObjectNoDefinition: any = (definitionObject: any, _opts: any, ctx: any) => {
+  if (definitionObject?.type === "") {
+    return [{ message: errorMessage, path: ctx.path }]
+  }
+  const valuess = Object.values(definitionObject)
+  for (const val of valuess) {
+    if (typeof val === "object") return []
+    else continue
+  }
+  return [{ message: errorMessage, path: ctx.path }]
+}

--- a/packages/rulesets/src/spectral/test/properties-type-object-no-definition.test.ts
+++ b/packages/rulesets/src/spectral/test/properties-type-object-no-definition.test.ts
@@ -1,0 +1,153 @@
+import { Spectral } from "@stoplight/spectral-core"
+import linterForRule from "./utils"
+let linter: Spectral
+const errorMessage =
+  "If Properties with type:object dont have a reference model defined, then the allowed types can only be primitive data types."
+beforeAll(async () => {
+  linter = await linterForRule("PropertiesTypeObjectNoDefinition")
+  return linter
+})
+test("PropertiesTypeObjectNoDefinition should find errors", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    definitions: {
+      This: {
+        description: "This",
+        type: "object",
+        additionalProperties: {
+          type: "",
+        },
+        tags: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            info: {
+              type: "string",
+            },
+          },
+        },
+        properties: {
+          type: "object",
+        },
+      },
+      That: {
+        description: "That",
+        type: "object",
+        properties: {
+          type: "object",
+          params: {
+            type: "object",
+          },
+        },
+      },
+      ThaOther: {
+        description: "ThaOther",
+        type: "object",
+        properties: {
+          type: "object",
+          params: {
+            type: "string",
+          },
+        },
+        params: {
+          type: "object",
+        },
+      },
+      Other: {
+        description: "Other",
+        type: "object",
+        properties: {
+          type: "object",
+          params: {
+            type: "object",
+            params: {
+              type: "object",
+            },
+          },
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(5)
+    expect(results[0].path.join(".")).toBe("definitions.This.additionalProperties")
+    expect(results[1].path.join(".")).toBe("definitions.This.properties")
+    expect(results[2].path.join(".")).toBe("definitions.That.properties.params")
+    expect(results[3].path.join(".")).toBe("definitions.ThaOther.params")
+    expect(results[4].path.join(".")).toBe("definitions.Other.properties.params.params")
+    expect(results[0].message).toBe(errorMessage)
+    expect(results[1].message).toBe(errorMessage)
+    expect(results[2].message).toBe(errorMessage)
+    expect(results[3].message).toBe(errorMessage)
+    expect(results[4].message).toBe(errorMessage)
+  })
+})
+test("PropertiesTypeObjectNoDefinition should find no errors", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    definitions: {
+      This: {
+        description: "This",
+        type: "object",
+        properties: {
+          type: "string",
+        },
+      },
+      That: {
+        description: "That",
+        type: "object",
+        properties: {
+          type: "object",
+          params: {
+            type: "boolean",
+          },
+        },
+      },
+      ThaOther: {
+        description: "ThaOther",
+        type: "object",
+        properties: {
+          type: "object",
+          info: {
+            type: "string",
+            description: "ThaOther",
+            readOnly: true,
+          },
+        },
+        params: {
+          type: "string",
+        },
+        ErrorAdditionalInfo: {
+          type: "object",
+          properties: {
+            type: {
+              readOnly: true,
+              type: "string",
+              description: "The additional info type.",
+            },
+          },
+          description: "The resource management error additional info.",
+        },
+        ErrorAdditionalInfo1: {
+          type: "object",
+          properties: {
+            type: "object",
+            properties: {
+              readOnly: true,
+              type: "string",
+              description: "The additional info type.",
+            },
+            info1: {
+              readOnly: true,
+              type: "string",
+            },
+          },
+          description: "The resource management error additional info.",
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
This rule check for the property "type": "object" with no object definition or property with type null "type": ""
If the object is not defined or if its null mark as an error

Example with Error
 description: "Properties check for type object",
        type: "object",
        properties: {
          type: "object",
          params: {
            type: "object",
            description: " Params with no further definition."
          },
         info: {
            type: "",
         }
        },
      
Example with no Error
 description: "Properties check for type object",
        type: "object",
        properties: {
          type: "object",
          params: {
            type: "object",
            description: "Type object has info as definition with type string."
             info: {
                type: "string",
           }
          },
        },