### PR TITLE
Add support for `is-staging-run` which disables staging-only Spectral rules in production runs. Update relevant doc on rule disabling.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,6 +48,7 @@
     "source.fixAll.eslint": true
   },
   "cSpell.words": [
-    "ruleset"
+    "ruleset",
+    "rulesets"
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
     + [Production LintDiff CI check](#production-lintdiff-ci-check)
     + [Staging LintDiff CI check](#staging-lintdiff-ci-check)
 - [How to run LintDiff locally from source](#how-to-run-lintdiff-locally-from-sources)
-- [How to disable or enable existing Spectral rules](#how-to-disable-or-enable-existing-spectral-rules)
+- [How to set a Spectral rule to run only in staging](#how-to-set-a-spectral-rule-to-run-only-in-staging)
 - [How to verify which Spectral rules are running in Production and Staging LintDiff](#how-to-verify-which-spectral-rules-are-running-in-production-and-staging-lintdiff)
 - [Installing NPM dependencies](#installing-npm-dependencies)
 - [How to test](#how-to-test)
@@ -225,11 +225,18 @@ but instead of `--use=<api-version>` use `--use=./packages/azure-openapi-validat
 
    > **Troubleshooting**: if you get `error   |   Error: Can only create file URIs from absolute paths. Got 'packages\azure-openapi-validator\autorest\readme.md'` then ensure you passed `--use=./packages/azure-openapi-validator/autorest` and not `--use=packages/azure-openapi-validator/autorest`.
 
-# How to disable or enable existing Spectral rules
+# How to set a Spectral rule to run only in staging
 
-- Set the Spectral rule severity to `off` to disable it. Revert that to enable it back.
-  - For an example of 3 rules being disabled, see [this file diff](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-4c1382203db84bcd9df61a5bbf90823d0e1f39a833e8eaa1a5be96ca4a4e9b61).
-- Follow the instructions given in the [`How to deploy your changes`](#how-to-deploy-your-changes) section.
+1. Given a Spectral rule definition. e.g. [ProvisioningStateSpecifiedForLROPut in az-arm.ts](https://github.com/Azure/azure-openapi-validator/blob/225d507ede59ab5371dd84328422c9f525dca21c/packages/rulesets/src/spectral/az-arm.ts#LL82C5-L82C40),
+you can disable it from running in production by adding `stagingOnly: true` property.
+Don't forget to add a comma at the end!
+   - The rules are disabled only for production runs. Staging LintDiff runs always run all enabled Spectral rules.
+   - For an example of few rules being set to `stagingOnly`, see [this file diff](https://github.com/Azure/azure-openapi-validator/pull/506/files#diff-4c1382203db84bcd9df61a5bbf90823d0e1f39a833e8eaa1a5be96ca4a4e9b61).
+2. Follow the instructions given in the [`How to deploy your changes`](#how-to-deploy-your-changes) section.
+
+To re-enable the rule for production runs, delete the property and re-deploy the rule.
+
+If you want to completely disable a rule then change its severity to `"off"`.
 
 # How to verify which Spectral rules are running in Production and Staging LintDiff
 

--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/staging_enable_rules_2023-06-06-22-54.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/staging_enable_rules_2023-06-06-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "refactor internal names",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/common/changes/@microsoft.azure/openapi-validator/staging_enable_rules_2023-06-01-13-19.json
+++ b/common/changes/@microsoft.azure/openapi-validator/staging_enable_rules_2023-06-01-13-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator",
+      "comment": "Add support for \"is-staging-run\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator"
+}

--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Azure OpenAPI Validator",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2073,8 +2073,8 @@ const provisioningStateMustBeReadOnly = (schema, _opts, ctx) => {
     return errors;
 };
 
-const putGetPatchScehma = (pathItem, opts, ctx) => {
-    if (pathItem === null || typeof pathItem !== 'object') {
+const putGetPatchSchema = (pathItem, opts, ctx) => {
+    if (pathItem === null || typeof pathItem !== "object") {
         return [];
     }
     const neededHttpVerbs = ["put", "get", "patch"];
@@ -2088,7 +2088,7 @@ const putGetPatchScehma = (pathItem, opts, ctx) => {
         if (models.size > 1) {
             errors.push({
                 message: "",
-                path
+                path,
             });
             break;
         }
@@ -2816,7 +2816,7 @@ const ruleset = {
             resolved: false,
             given: ["$[paths,'x-ms-paths'].*.put^"],
             then: {
-                function: putGetPatchScehma,
+                function: putGetPatchSchema,
             },
         },
         XmsResourceInPutResponse: {

--- a/packages/rulesets/src/index.ts
+++ b/packages/rulesets/src/index.ts
@@ -5,7 +5,7 @@ import azARM from "./spectral/az-arm"
 import azCommon from "./spectral/az-common"
 import azDataplane from "./spectral/az-dataplane"
 
-const spectralRulesetDir = join (__dirname,"spectral")
+const spectralRulesetDir = join(__dirname, "spectral")
 export const spectralCommonRulesetFile = join(spectralRulesetDir, "az-common.js")
 export const spectralArmRulesetFile = join(spectralRulesetDir, "az-arm.js")
 export const spectralDataplaneRulesetFile = join(spectralRulesetDir, "az-dataplane.js")
@@ -13,9 +13,9 @@ export const spectralDataplaneRulesetFile = join(spectralRulesetDir, "az-datapla
 export const spectralRulesets = {
   azARM,
   azCommon,
-  azDataplane
+  azDataplane,
 }
 export const nativeRulesets = {
-  azCommon:commonRuleset,
-  azArm:armRuleset
+  azCommon: commonRuleset,
+  azArm: armRuleset,
 }

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -31,7 +31,7 @@ import pathSegmentCasing from "./functions/path-segment-casing"
 import { propertiesTypeObjectNoDefinition } from "./functions/properties-type-object-no-definition"
 import provisioningState from "./functions/provisioning-state"
 import { provisioningStateMustBeReadOnly } from "./functions/provisioning-state-must-be-read-only"
-import putGetPatchScehma from "./functions/put-get-patch-schema"
+import putGetPatchSchema from "./functions/put-get-patch-schema"
 import { putRequestResponseScheme } from "./functions/put-request-response-scheme"
 import { PutResponseSchemaDescription } from "./functions/put-response-schema-description"
 import { reservedResourceNamesModelAsEnum } from "./functions/reserved-resource-names-model-as-enum"
@@ -452,7 +452,7 @@ const ruleset: any = {
       resolved: false,
       given: ["$[paths,'x-ms-paths'].*.put^"],
       then: {
-        function: putGetPatchScehma,
+        function: putGetPatchSchema,
       },
     },
     // RPC Code: RPC-Put-V1-12

--- a/packages/rulesets/src/spectral/functions/put-get-patch-schema.ts
+++ b/packages/rulesets/src/spectral/functions/put-get-patch-schema.ts
@@ -1,32 +1,32 @@
 // Check a sku model to ensure it must have a name property. It can also have 'tier', 'size', 'family', 'capacity' as optional properties.
 
-import {  RulesetFunctionContext } from "@stoplight/spectral-core";
-import { getReturnedType } from "./utils";
+import { RulesetFunctionContext } from "@stoplight/spectral-core"
+import { getReturnedType } from "./utils"
 
-const putGetPatchScehma: any = (pathItem:any, opts:any, ctx:RulesetFunctionContext) => {
-  if (pathItem === null || typeof pathItem !== 'object') {
-    return [];
+const putGetPatchSchema: any = (pathItem: any, opts: any, ctx: RulesetFunctionContext) => {
+  if (pathItem === null || typeof pathItem !== "object") {
+    return []
   }
 
-  const neededHttpVerbs = ["put","get","patch"]
+  const neededHttpVerbs = ["put", "get", "patch"]
 
-  const path = ctx.path || [];
+  const path = ctx.path || []
   const errors = []
-  const models = new Set<string|null>()
-  
-  for (const verb of neededHttpVerbs ) {
-    if (pathItem[verb]){
+  const models = new Set<string | null>()
+
+  for (const verb of neededHttpVerbs) {
+    if (pathItem[verb]) {
       models.add(getReturnedType(pathItem[verb]))
     }
     if (models.size > 1) {
       errors.push({
-        message:"",
-        path
+        message: "",
+        path,
       })
       break
     }
   }
-  return errors;
-};
+  return errors
+}
 
-export default putGetPatchScehma
+export default putGetPatchSchema

--- a/packages/rulesets/src/spectral/test/utils.ts
+++ b/packages/rulesets/src/spectral/test/utils.ts
@@ -4,46 +4,44 @@ import { DiagnosticSeverity } from "@stoplight/types"
 import _ from "lodash"
 import { spectralRulesets } from "../../index"
 
-export function buildLinter(ruleset: any, rule: string, useNoopResolver = false) {
-  const omitRule = (extend: any, ruleName: string) => {
-    const ruleset: any = Array.isArray(extend) ? extend[0] : extend
-    Object.keys(ruleset.rules).forEach((key: string) => {
-      if (key !== ruleName) {
-        delete ruleset.rules[key]
+export function buildLinter(rulesets: any[], testedRuleName: string, useNoopResolver = false) {
+  // Delete all rules except the tested rule
+  rulesets.forEach((ruleset: any) => {
+    Object.keys(ruleset.rules).forEach((ruleName: string) => {
+      if (ruleName !== testedRuleName) {
+        delete ruleset.rules[ruleName]
       }
     })
-    ruleset?.extends?.forEach((extend: any) => {
-      omitRule(extend, rule)
-    })
-  }
+  })
 
-  omitRule(ruleset, rule)
+  // Delete the "stagingOnly" property for the same reasons as we do so in
+  // packages/azure-openapi-validator/autorest/src/spectral-plugin-func.ts/getRuleSet
+  rulesets.forEach((ruleset: any) => {
+    Object.values(ruleset.rules).forEach((rule: any) => delete rule.stagingOnly)
+  })
+
   const linter = useNoopResolver
     ? new Spectral({
         resolver: noopResolver(),
       })
     : new Spectral()
 
-  linter.setRuleset(ruleset)
+  linter.setRuleset({
+    extends: rulesets,
+    rules: {},
+  })
 
   // Here we ensure the rule-to-be-unit-tested severity is set to 'error',
   // to ensure its unit tests will correctly execute.
   // Without this, if the rule is disabled in its definition by having
   // 'severity' set to 'off', then its unit tests would likely fail.
-  linter.ruleset!.rules[rule].severity = DiagnosticSeverity.Error
+  linter.ruleset!.rules[testedRuleName].severity = DiagnosticSeverity.Error
 
   return linter
 }
 
-function linterForRule(rule: string, useNoopResolver = false): Spectral {
-  return buildLinter(
-    {
-      extends: _.cloneDeep(Object.values(spectralRulesets)),
-      rules: {},
-    },
-    rule,
-    useNoopResolver
-  )
+function linterForRule(ruleName: string, useNoopResolver = false): Spectral {
+  return buildLinter(_.cloneDeep(Object.values(spectralRulesets)), ruleName, useNoopResolver)
 }
 
 function noopResolver(): Resolver {


### PR DESCRIPTION
Add support for `is-staging-run` AutoRest argument which disables Spectral rules if given rule has property `stagingOnly: true` and `is-staging-run` is not passed or not set to true.

This feature makes it possible to deploy LintDiff changes to production without enabling rules that are not yet ready to be deployed to production, while still keeping them enabled in staging runs to verify their correctness. 

This PR also:
- updates relevant doc on rule disabling,
- simplifies the `utils.ts / buildLinter` method,
- does few minor source code symbols rename refactorings.

This PR requires a companion PR in `openapi-alps` repo to actually take advantage of the introduced flag. Here it is:
- https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps/pullrequest/475702

Following PR immediately takes advantage of changes introduced in this PR:
- https://github.com/Azure/azure-openapi-validator/pull/532

## Testing done

I ran LintDiff locally per the docs, using following cmd lines, differing by usage of `--is-staging-run=`: absent, `false` and `true`. I temporarily added `stagingOnly: true` to few rule definitions. The behavior was always as expected, disabling rules with `stagingOnly: true` when `--is-staging-run` was not passed or not set to `true`.

``` bash
autorest --v3 --spectral --azure-validator --use=./packages/azure-openapi-validator/autorest --tag=package-2022-09-preview ../specs-pr/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md

autorest --v3 --spectral --azure-validator --use=./packages/azure-openapi-validator/autorest --is-staging-run=false --tag=package-2022-09-preview ../specs-pr/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md

autorest --v3 --spectral --azure-validator --use=./packages/azure-openapi-validator/autorest --is-staging-run=true --tag=package-2022-09-preview ../specs-pr/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md
```