### PR TITLE
Set recently introduced ARM Spectral rules to `stagingOnly`, so they run only in Staging, not Prod.

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/disable_may_10_rules_2023-06-01-16-36.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/disable_may_10_rules_2023-06-01-16-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "disable recent unverified rules (since 5/10/2023) from running in production",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2581,6 +2581,7 @@ const ruleset = {
         DeleteResponseCodes: {
             description: "Synchronous DELETE must have 200 & 204 return codes and LRO DELETE must have 202 & 204 return codes.",
             severity: "error",
+            stagingOnly: true,
             message: "{{error}}",
             resolved: true,
             formats: [oas2],
@@ -2614,6 +2615,7 @@ const ruleset = {
         AvoidAdditionalProperties: {
             description: "The use of additionalProperties is not allowed except for user defined tags on tracked resources.",
             severity: "error",
+            stagingOnly: true,
             message: "{{description}}",
             resolved: true,
             formats: [oas2],
@@ -2625,6 +2627,7 @@ const ruleset = {
         PropertiesTypeObjectNoDefinition: {
             description: "Properties with type:object that don't reference a model definition are not allowed. ARM doesn't allow generic type definitions as this leads to bad customer experience.",
             severity: "error",
+            stagingOnly: true,
             message: "{{error}}",
             resolved: true,
             formats: [oas2],
@@ -3030,6 +3033,7 @@ const ruleset = {
             description: "Service-defined (reserved) resource names must be represented as an enum type with modelAsString set to true, not as a static string in the path.",
             message: "{{error}}",
             severity: "error",
+            stagingOnly: true,
             resolved: true,
             formats: [oas2],
             given: ["$[paths,'x-ms-paths']"],
@@ -3055,6 +3059,7 @@ const ruleset = {
             description: "The get operations endpoint must only be at the tenant level.",
             message: "{{error}}",
             severity: "error",
+            stagingOnly: true,
             resolved: true,
             formats: [oas2],
             given: "$.[paths,'x-ms-paths']",

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3071,6 +3071,7 @@ const ruleset = {
             description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
             message: "{{error}}",
             severity: "off",
+            stagingOnly: true,
             resolved: true,
             formats: [oas2],
             given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -160,6 +160,7 @@ const ruleset: any = {
     DeleteResponseCodes: {
       description: "Synchronous DELETE must have 200 & 204 return codes and LRO DELETE must have 202 & 204 return codes.",
       severity: "error",
+      stagingOnly: true,
       message: "{{error}}",
       resolved: true,
       formats: [oas2],
@@ -203,6 +204,7 @@ const ruleset: any = {
     AvoidAdditionalProperties: {
       description: "The use of additionalProperties is not allowed except for user defined tags on tracked resources.",
       severity: "error",
+      stagingOnly: true,
       message: "{{description}}",
       resolved: true,
       formats: [oas2],
@@ -217,6 +219,7 @@ const ruleset: any = {
       description:
         "Properties with type:object that don't reference a model definition are not allowed. ARM doesn't allow generic type definitions as this leads to bad customer experience.",
       severity: "error",
+      stagingOnly: true,
       message: "{{error}}",
       resolved: true,
       formats: [oas2],
@@ -710,6 +713,7 @@ const ruleset: any = {
         "Service-defined (reserved) resource names must be represented as an enum type with modelAsString set to true, not as a static string in the path.",
       message: "{{error}}",
       severity: "error",
+      stagingOnly: true,
       resolved: true,
       formats: [oas2],
       given: ["$[paths,'x-ms-paths']"],
@@ -743,6 +747,7 @@ const ruleset: any = {
       description: "The get operations endpoint must only be at the tenant level.",
       message: "{{error}}",
       severity: "error",
+      stagingOnly: true,
       resolved: true,
       formats: [oas2],
       given: "$.[paths,'x-ms-paths']",
@@ -758,7 +763,7 @@ const ruleset: any = {
     ProvisioningStateMustBeReadOnly: {
       description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
       message: "{{error}}",
-      severity: "off", // See https://github.com/Azure/azure-sdk-tools/issues/6071#issuecomment-1535560188
+      severity: "off", // See https://github.com/Azure/azure-sdk-tools/issues/6191#issuecomment-1571334585
       resolved: true,
       formats: [oas2],
       given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -764,6 +764,7 @@ const ruleset: any = {
       description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
       message: "{{error}}",
       severity: "off", // See https://github.com/Azure/azure-sdk-tools/issues/6191#issuecomment-1571334585
+      stagingOnly: true,
       resolved: true,
       formats: [oas2],
       given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],


### PR DESCRIPTION
This PR is setting to `stagingOnly` all rules added since May 10th as this was the most recent deployment of ruleset:
- https://www.npmjs.com/package/@microsoft.azure/openapi-validator-rulesets?activeTab=versions

To figure out which rules needed to be set to `stagingOnly`, I looked at all changes made to `az-arm.ts` after May 10th, per:
- https://github.com/Azure/azure-openapi-validator/commits/main/packages/rulesets/src/spectral/az-arm.ts

This PR **cannot be merged** until the following PRs are deployed to production:

- https://github.com/Azure/azure-openapi-validator/pull/531
- https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps/pullrequest/475702

Update: Prerequisites deployed via:
- https://dev.azure.com/azure-sdk/internal/_releaseProgress?_a=release-environment-logs&releaseId=23317&environmentId=28948
- https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7892511&view=results
- https://github.com/Azure/azure-rest-api-specs-pipeline/commit/1694613959f06dc1e3f448ca77f4e408512a7433