### PR TITLE
Allow "format: uri" in dataplane

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/format-uri_2023-06-02-16-29.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/format-uri_2023-06-02-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Allow format: uri in dataplane",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1126,6 +1126,7 @@ The well-defined type/format combinations are:
 | uuid              |                              | from [AutoRest][autorest] |
 | base64url         |                              | from [AutoRest][autorest] |
 | url               |                              | from [AutoRest][autorest] |
+| uri               |                              | from [AutoRest][autorest] |
 | odata-query       |                              | from [AutoRest][autorest] |
 | certificate       |                              | from [AutoRest][autorest] |
 [oas2]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#data-types

--- a/packages/rulesets/generated/spectral/az-dataplane.js
+++ b/packages/rulesets/generated/spectral/az-dataplane.js
@@ -1811,6 +1811,7 @@ function checkSchemaTypeAndFormat(schema, options, { path }) {
         "uuid",
         "base64url",
         "url",
+        "uri",
         "odata-query",
         "certificate",
     ];

--- a/packages/rulesets/src/spectral/functions/schema-type-and-format.ts
+++ b/packages/rulesets/src/spectral/functions/schema-type-and-format.ts
@@ -37,6 +37,7 @@ function checkSchemaTypeAndFormat(schema: Oas2Schema, options: any, { path }: { 
     "uuid",
     "base64url",
     "url",
+    "uri",
     "odata-query",
     "certificate",
   ]

--- a/packages/rulesets/src/spectral/test/schema-type-and-format.test.ts
+++ b/packages/rulesets/src/spectral/test/schema-type-and-format.test.ts
@@ -228,6 +228,10 @@ test("az-schema-type-and-format should find no errors", () => {
         type: "string",
         format: "url",
       },
+      PropZZ2: {
+        type: "string",
+        format: "uri",
+      },
       ModelA: {
         type: "object",
         properties: {


### PR DESCRIPTION
This PR makes a small change to the SchemaTypeAndFormat rule to allow `format: uri` for data plane REST APIs. This rule only runs for data plane, and the corresponding rule for ARM, [ValidFormats](https://github.com/Azure/azure-openapi-validator/blob/main/docs/valid-formats.md) already allows `format: uri`.  Autorest accepts `format: uri` as equivalent to `format: url`.

Tests and documentation have been updated.