### PR TITLE
fixing the documentation and error message for CreateOperationAsyncResponseValidation

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fixFalseAlarmForCreateOperationAsyncResponseValidation_2023-06-03-16-47.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fixFalseAlarmForCreateOperationAsyncResponseValidation_2023-06-03-16-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "fixing documenation and error message for CreateOperationAsyncResponseValidation to be in sync with the implementation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/create-operation-async-response-validation.md
+++ b/docs/create-operation-async-response-validation.md
@@ -18,7 +18,7 @@ ARM OpenAPI(swagger) specs
 
 ## Description
 
-An async PUT operation response must include status code 201 for creates. It must also support status code 200, for replace. The operation must also add "x-ms-long-running-operation" to mark that it is a long running operation.
+An async PUT operation response must include status code 201 for creation. It must also support status code 200, for replacement. The operation must also add "x-ms-long-running-operation" to mark that it is a long running operation.
 
 ## CreatedAt
 

--- a/docs/create-operation-async-response-validation.md
+++ b/docs/create-operation-async-response-validation.md
@@ -14,11 +14,11 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-Only 201 is the supported response code for PUT async response
+202 is not a supported response code for PUT async response
 
 ## Description
 
-An async PUT operation response include status code 201 with 'Azure-async-operation' header. Must also support status code 200, for simple updates that can be completed synchronously (ex: tags). Operation must also add "x-ms-long-running-operation and x-ms-long-running-operation-options" to mark that it is a long running operation (in case of 201) and how it is tracked (Azure-async-operation header).
+An async PUT operation response must include status code 201 for creates. It must also support status code 200, for replace. The operation must also add "x-ms-long-running-operation" to mark that it is a long running operation.
 
 ## CreatedAt
 
@@ -60,9 +60,6 @@ The following would be valid:
         }
       }
     },
-    "x-ms-long-running-operation": true,
-    "x-ms-long-running-operation-options": {
-      "final-state-via": "azure-async-operation"
-  }
+    "x-ms-long-running-operation": true
 ...
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -170,7 +170,7 @@ Please refer to [control-characters-not-allowed.md](./control-characters-not-all
 
 ### CreateOperationAsyncResponseValidation
 
-An async PUT operation response include status code 201 with 'Azure-async-operation' header. Must also support status code 200, for simple updates that can be completed synchronously (ex: tags). Operation must also add "x-ms-long-running-operation and x-ms-long-running-operation-options" to mark that it is a long running operation (in case of 201) and how it is tracked (Azure-async-operation header).
+An async PUT operation response must include status code 201 for creates. It must also support status code 200, for replace. The operation must also add "x-ms-long-running-operation" to mark that it is a long running operation.
 
 Please refer to [create-operation-async-response-validation.md](./create-operation-async-response-validation.md) for details.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -170,7 +170,7 @@ Please refer to [control-characters-not-allowed.md](./control-characters-not-all
 
 ### CreateOperationAsyncResponseValidation
 
-An async PUT operation response must include status code 201 for creates. It must also support status code 200, for replace. The operation must also add "x-ms-long-running-operation" to mark that it is a long running operation.
+An async PUT operation response must include status code 201 for creation. It must also support status code 200, for replacement. The operation must also add "x-ms-long-running-operation" to mark that it is a long running operation.
 
 Please refer to [create-operation-async-response-validation.md](./create-operation-async-response-validation.md) for details.
 

--- a/packages/rulesets/src/native/legacyRules/CreateOperationAsyncResponseValidation.ts
+++ b/packages/rulesets/src/native/legacyRules/CreateOperationAsyncResponseValidation.ts
@@ -16,7 +16,7 @@ rules.push({
   *run(doc, node, path) {
     if (node.responses["202"]) {
       yield {
-        message: `Only 201 is the supported response code for PUT async response.`,
+        message: `202 is not a supported response code for PUT async response.`,
         location: path.concat(["responses", "202"]),
       }
     }

--- a/packages/rulesets/src/native/legacyRules/CreateOperationAsyncResponseValidation.ts
+++ b/packages/rulesets/src/native/legacyRules/CreateOperationAsyncResponseValidation.ts
@@ -16,7 +16,7 @@ rules.push({
   *run(doc, node, path) {
     if (node.responses["202"]) {
       yield {
-        message: `202 is not a supported response code for PUT async response.`,
+        message: `202 is not a supported response code for PUT async response. Please use 201 instead.`,
         location: path.concat(["responses", "202"]),
       }
     }


### PR DESCRIPTION
The implementation for CreateOperationAsyncResponseValidation does not check for the existence of the x-ms-long-running-operation extension any more but the documentation still indicates that it does this check.
Also the error message for 202 violation indicates that 201 is to be used for async. I have edited it to make this a bit more clear.

Task - [Task 23293632](https://msazure.visualstudio.com/One/_workitems/edit/23293632): [LintDiff] [~[Staging] Swagger LintDiff failed] Conflicting validation rules for Async operations

Related to:
- https://github.com/Azure/azure-sdk-tools/issues/6198