### PR TITLE
fix verifyArmPath to account for third party RP namespaces

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-PathContainsResourceType_2023-06-15-17-44.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-PathContainsResourceType_2023-06-15-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "fix verifyArmPath to account for third party RP namespaces",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1285,15 +1285,15 @@ function verifyResourceGroupScope(path) {
     return matchAnyPatterns(patterns, path);
 }
 function verifyResourceType(path) {
-    const patterns = [/^.*\/providers\/microsoft\.\w+\/\w+.*/gi];
+    const patterns = [/^.*\/providers\/\w+\.\w+\/\w+.*/gi];
     return matchAnyPatterns(patterns, path);
 }
 function verifyNestResourceType(path) {
     const patterns = [
-        /^.*\/providers\/microsoft\.\w+\/\w+\/{\w+}(?:\/\w+\/(?!default)\w+){1,2}$/gi,
-        /^.*\/providers\/microsoft\.\w+(?:\/\w+\/(default|{\w+})){1,2}(?:\/\w+\/(?!default)\w+)+$/gi,
-        /^.*\/providers\/microsoft\.\w+\/\w+\/(?:\/\w+\/(default|{\w+})){0,3}{\w+}(?:\/{\w+})+.*$/gi,
-        /^.*\/providers\/microsoft\.\w+(?:\/\w+\/(default|{\w+})){0,2}(?:\/\w+\/(?!default)\w+)+\/{\w+}.*$/gi,
+        /^.*\/providers\/\w+\.\w+\/\w+\/{\w+}(?:\/\w+\/(?!default)\w+){1,2}$/gi,
+        /^.*\/providers\/\w+\.\w+(?:\/\w+\/(default|{\w+})){1,2}(?:\/\w+\/(?!default)\w+)+$/gi,
+        /^.*\/providers\/\w+\.\w+\/\w+\/(?:\/\w+\/(default|{\w+})){0,3}{\w+}(?:\/{\w+})+.*$/gi,
+        /^.*\/providers\/\w+\.\w+(?:\/\w+\/(default|{\w+})){0,2}(?:\/\w+\/(?!default)\w+)+\/{\w+}.*$/gi,
     ];
     return notMatchPatterns(patterns, path);
 }

--- a/packages/rulesets/src/spectral/functions/arm-path-validation.ts
+++ b/packages/rulesets/src/spectral/functions/arm-path-validation.ts
@@ -51,7 +51,7 @@ function verifyResourceType(path: string) {
   //  2 <scope>/providers/{resourceName}...
   //  3 <scope>/providers/ResourceType/...
   //  4 /providers/Microsoft.Compute/{vmName}
-  const patterns = [/^.*\/providers\/microsoft\.\w+\/\w+.*/gi]
+  const patterns = [/^.*\/providers\/\w+\.\w+\/\w+.*/gi]
   return matchAnyPatterns(patterns, path)
 }
 
@@ -61,13 +61,13 @@ function verifyNestResourceType(path: string) {
 
   const patterns = [
     // 1 <scope>/providers/Microsoft.Compute/virtualMachine/{vmName}/nestedResourceType/actions
-    /^.*\/providers\/microsoft\.\w+\/\w+\/{\w+}(?:\/\w+\/(?!default)\w+){1,2}$/gi,
+    /^.*\/providers\/\w+\.\w+\/\w+\/{\w+}(?:\/\w+\/(?!default)\w+){1,2}$/gi,
     // 2 <scope>/providers/Microsoft.Compute/virtualMachine/{vmName}/nestedTypes/{nestedResourceType}/action1/action2..
-    /^.*\/providers\/microsoft\.\w+(?:\/\w+\/(default|{\w+})){1,2}(?:\/\w+\/(?!default)\w+)+$/gi,
+    /^.*\/providers\/\w+\.\w+(?:\/\w+\/(default|{\w+})){1,2}(?:\/\w+\/(?!default)\w+)+$/gi,
     // 3 <scope>/providers/Microsoft.Compute/virtualMachine/{vmName}/{nestedResourceType}
-    /^.*\/providers\/microsoft\.\w+\/\w+\/(?:\/\w+\/(default|{\w+})){0,3}{\w+}(?:\/{\w+})+.*$/gi,
+    /^.*\/providers\/\w+\.\w+\/\w+\/(?:\/\w+\/(default|{\w+})){0,3}{\w+}(?:\/{\w+})+.*$/gi,
     // 4 <scope>/providers/Microsoft.Compute/virtualMachine/nestedResourceType/{nestedResourceType}
-    /^.*\/providers\/microsoft\.\w+(?:\/\w+\/(default|{\w+})){0,2}(?:\/\w+\/(?!default)\w+)+\/{\w+}.*$/gi,
+    /^.*\/providers\/\w+\.\w+(?:\/\w+\/(default|{\w+})){0,2}(?:\/\w+\/(?!default)\w+)+\/{\w+}.*$/gi,
   ]
   return notMatchPatterns(patterns, path)
 }

--- a/packages/rulesets/src/spectral/test/arm-path-validation.test.ts
+++ b/packages/rulesets/src/spectral/test/arm-path-validation.test.ts
@@ -60,6 +60,142 @@ test("PathContainsResourceType should find errors for invalid path", () => {
   })
 })
 
+test("PathContainsResourceType should find errors for invalid path for third party RPs", () => {
+  // invalid paths:
+  //  1 <scope>/providers/PureStorage.Krypton/{vmName}
+  //  2 <scope>/providers/{resourceName}/PureStorage.Krypton...
+  //  3 <scope>/providers/ResourceType/PureStorage.Krypton...
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/providers/PureStorage.Krypton/{resourceName}/resourceType": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/providers/{resourceName}/PureStorage.Krypton/resourceType": {
+        get: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/providers/resourceType/PureStorage.Krypton/resourceType": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathContainsResourceType.run(oasDoc).then((results) => {
+    expect(results.length).toBe(3)
+    expect(results[0].message).toContain("The path for the CURD methods do not contain a resource type.")
+    expect(results[0].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/providers/PureStorage.Krypton/{resourceName}/resourceType"
+    )
+    expect(results[1].message).toContain("The path for the CURD methods do not contain a resource type.")
+    expect(results[1].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/providers/{resourceName}/PureStorage.Krypton/resourceType"
+    )
+    expect(results[2].message).toContain("The path for the CURD methods do not contain a resource type.")
+    expect(results[2].path.join(".")).toBe("paths./subscriptions/{subscriptionId}/providers/resourceType/PureStorage.Krypton/resourceType")
+  })
+})
+
+test("PathContainsResourceType should find no errors for valid path", () => {
+  // valid paths:
+  //  1 <scope>/providers/Microsoft.Compute/virtualMachines/{vmName}
+  //  2 <scope>/providers/Microsoft.Compute/virtualMachines
+  //  3 /providers/Microsoft.Compute/virtualMachines
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/providers/Microsoft.MyNs/resourceType/{resourceName}": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/providers/Microsoft.MyNs/resourceType": {
+        get: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Get",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/providers/Microsoft.MyNs/resourceType": {
+        get: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Get",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathContainsResourceType.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("PathContainsResourceType should find no errors for valid paths for third party RPs", () => {
+  // valid paths:
+  //  1 <scope>/providers/PureStorage.Krypton/virtualMachines/{vmName}
+  //  2 <scope>/providers/PureStorage.Krypton/virtualMachines
+  //  3 /providers/PureStorage.Krypton/virtualMachines
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/providers/PureStorage.Krypton/resourceType/{resourceName}": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/providers/PureStorage.Krypton/resourceType": {
+        get: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Get",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/providers/PureStorage.Krypton/resourceType": {
+        get: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Get",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathContainsResourceType.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
 test("PathContainsResourceGroup should find errors for invalid path", () => {
   // invalid paths:
   //  1 <scope>/providers/Microsoft.Compute/{vmName}
@@ -88,6 +224,34 @@ test("PathContainsResourceGroup should find errors for invalid path", () => {
   })
 })
 
+test("PathContainsResourceGroup should find errors for invalid path for third party RPs", () => {
+  // invalid paths:
+  //  1 <scope>/providers/PureStorage.Krypton/{vmName}
+  //  2 <scope>/providers/{resourceName}/PureStorage.Krypton...
+  //  3 <scope>/providers/ResourceType/PureStorage.Krypton...
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/resourceGroups/providers/PureStorage.Krypton/{resourceName}/resourceType": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathContainsResourceGroup.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1)
+    expect(results[0].message).toContain("The path for resource group scoped CRUD methods does not contain a resourceGroupName parameter.")
+    expect(results[0].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/resourceGroups/providers/PureStorage.Krypton/{resourceName}/resourceType"
+    )
+  })
+})
+
 test("PathContainsSubscription should find errors for invalid path", () => {
   // invalid paths:
   //  1 <scope>/providers/Microsoft.Compute/{vmName}
@@ -111,6 +275,32 @@ test("PathContainsSubscription should find errors for invalid path", () => {
     expect(results.length).toBe(1)
     expect(results[0].message).toContain("The path for the subscriptions scoped CRUD methods do not contain the subscriptionId parameter.")
     expect(results[0].path.join(".")).toBe("paths./subscriptions/resourceGroups/providers/Microsoft.MyNs/{resourceName}/resourceType")
+  })
+})
+
+test("PathContainsSubscription should find errors for invalid path for thirs party RPs", () => {
+  // invalid paths:
+  //  1 <scope>/providers/PureStorage.Krypton/{vmName}
+  //  2 <scope>/providers/{resourceName}/PureStorage.Krypton...
+  //  3 <scope>/providers/ResourceType/PureStorage.Krypton...
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/resourceGroups/providers/PureStorage.Krypton/{resourceName}/resourceType": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathContainsSubscriptionId.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1)
+    expect(results[0].message).toContain("The path for the subscriptions scoped CRUD methods do not contain the subscriptionId parameter.")
+    expect(results[0].path.join(".")).toBe("paths./subscriptions/resourceGroups/providers/PureStorage.Krypton/{resourceName}/resourceType")
   })
 })
 
@@ -146,6 +336,43 @@ test("PathForPutOperation should find errors for invalid path", () => {
     expect(results.length).toBe(1)
     expect(results[0].message).toContain("The path for 'put' operation must be under a subscription and resource group.")
     expect(results[0].path.join(".")).toBe("paths./subscriptions/{subscriptionId}/providers/Microsoft.MyNs/resourceType/{resourceName}")
+  })
+})
+
+test("PathForPutOperation should find errors for invalid path for thirs party RPs", () => {
+  // invalid paths:
+  //  1 <scope>/providers/PureStorage.Krypton/{vmName}
+  //  2 <scope>/providers/{resourceName}/PureStorage.Krypton...
+  //  3 <scope>/providers/ResourceType/PureStorage.Krypton...
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/{scope}/providers/PureStorage.Krypton/virtualMachine/{vmName}": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/providers/PureStorage.Krypton/resourceType/{resourceName}": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathForPutOperation.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1)
+    expect(results[0].message).toContain("The path for 'put' operation must be under a subscription and resource group.")
+    expect(results[0].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/providers/PureStorage.Krypton/resourceType/{resourceName}"
+    )
   })
 })
 
@@ -208,11 +435,91 @@ test("PathForNestedResource should find errors for invalid path", () => {
   })
 })
 
+test("PathForNestedResource should find errors for invalid path for third party RPs", () => {
+  // invalid paths:
+  //  1 <scope>/providers/PureStorage.Krypton/{vmName}
+  //  2 <scope>/providers/{resourceName}/PureStorage.Krypton...
+  //  3 <scope>/providers/ResourceType/PureStorage.Krypton...
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/{scope}/providers/PureStorage.Krypton/virtualMachine/{vmName}/disk/diskList": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/{scope}/providers/PureStorage.Krypton/virtualMachine/{vmName}/disk/{diskName}/DiskSize/list": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/{scope}/providers/PureStorage.Krypton/virtualMachine/{vmName}/disk/default": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/{scope}/providers/PureStorage.Krypton/privateClouds/{privateCloudName}/autoscalehistory/limit/{limit}": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathForNestedResource.run(oasDoc).then((results) => {
+    expect(results.length).toBe(3)
+    expect(results[0].message).toContain("The path for nested resource doest not meet the valid resource pattern.")
+    expect(results[0].path.join(".")).toBe("paths./{scope}/providers/PureStorage.Krypton/virtualMachine/{vmName}/disk/diskList")
+    expect(results[1].path.join(".")).toBe(
+      "paths./{scope}/providers/PureStorage.Krypton/virtualMachine/{vmName}/disk/{diskName}/DiskSize/list"
+    )
+    expect(results[2].path.join(".")).toBe(
+      "paths./{scope}/providers/PureStorage.Krypton/privateClouds/{privateCloudName}/autoscalehistory/limit/{limit}"
+    )
+  })
+})
+
 test("PathForNestedResource should find no errors", () => {
   const oasDoc = {
     swagger: "2.0",
     paths: {
       "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/providers/Microsoft.SecurityInsights/contentTemplates/{templateId}":
+        {
+          put: {
+            tags: ["SampleTag"],
+            operationId: "Foo_CreateOrUpdate",
+            description: "Test Description",
+            parameters: [],
+            responses: {},
+          },
+        },
+    },
+  }
+  return linters.PathForNestedResource.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("PathForNestedResource should find no errors for third party RPs", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PureStorage.Krypton/workspaces/{workspaceName}/providers/PureStorage.Krypton/contentTemplates/{templateId}":
         {
           put: {
             tags: ["SampleTag"],
@@ -270,6 +577,52 @@ test("PathForResourceAction should find errors for invalid path and no errors fo
     expect(results[0].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
     expect(results[1].path.join(".")).toBe(
       "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}"
+    )
+    expect(results[1].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
+  })
+})
+
+test("PathForResourceAction should find errors for invalid path and no errors for valid path for third party RPs", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PureStorage.Krypton": {
+        post: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PureStorage.Krypton/Songs/{songName}": {
+        post: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PureStorage.Krypton/Songs/{songName}/addSong": {
+        post: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linters.PathForResourceAction.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2)
+    expect(results[0].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PureStorage.Krypton"
+    )
+    expect(results[0].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
+    expect(results[1].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PureStorage.Krypton/Songs/{songName}"
     )
     expect(results[1].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
   })


### PR DESCRIPTION
This PR is to fix a false alarm where some rules like PathContainsResourceType are flagging false alarms when the namespace belongs to third party resource providers. The false alarm is because the verifyArmPath function looks for the term "microsoft" in the path and third party RP namespacds do not start with Microsoft.

To fix this the regex is being adjusted. Specifically the term "Microsoft" is being replaced with the regex \w+ which will allow any word chars in that segment. Retaining the '\.' pattern after that ensures that the segment following the "providers" segment is always a namespace.  

[Task 24144065](https://msazure.visualstudio.com/One/_workitems/edit/24144065): [LintDiff][False positive] PathContainsResourceType