### PR TITLE
GetCollectionResponseSchema false negative reproduction

### DIFF
--- a/packages/rulesets/src/native/tests/composite-azure-tests.ts
+++ b/packages/rulesets/src/native/tests/composite-azure-tests.ts
@@ -100,6 +100,12 @@ describe("CompositeAzureTests", () => {
     assertValidationRuleCount(messages, GetCollectionResponseSchema, 1)
   })
 
+  test("get collection response schema should match the ARM specification 1", async () => {
+    const fileName = "armResource/daprResiliencyPolicies.json"
+    const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, GetCollectionResponseSchema)
+    assertValidationRuleCount(messages, GetCollectionResponseSchema, 0)
+  })
+
   test("all resources must have get operation", async () => {
     const fileName = "armResource/cluster.json"
     const messages: LintResultMessage[] = await collectTestMessagesFromValidator(

--- a/packages/rulesets/src/native/tests/resources/armResource/daprResiliencyPolicies.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/daprResiliencyPolicies.json
@@ -1,0 +1,791 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2022-11-01-preview",
+    "title": "ContainerApps API Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprResiliencyCircuitBreakerPolicies": {
+      "get": {
+        "tags": [
+          "DaprResiliencyCircuitBreakerPolicies"
+        ],
+        "summary": "Get the Dapr Resiliency Circuit Breaker Policies for a managed environment.",
+        "operationId": "DaprResiliencyCircuitBreakerPolicies_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyCircuitBreakerPoliciesCollection"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr Resiliency Circuit Breaker Policy": {
+            "name": "./examples/DaprResiliencyCircuitBreakerPolicies_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprResiliencyCircuitBreakerPolicies/{policyName}": {
+      "get": {
+        "tags": [
+          "DaprResiliencyCircuitBreakerPolicies"
+        ],
+        "summary": "Get a Dapr Resiliency Circuit Breaker policy.",
+        "operationId": "DaprResiliencyCircuitBreakerPolicies_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Name of the Dapr resiliency circuit breaker policy.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyCircuitBreakerPolicy"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr Resiliency Circuit Breaker Policy": {
+            "name": "./examples/DaprResiliencyCircuitBreakerPolicies_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprResiliencyRetryPolicies": {
+      "get": {
+        "tags": [
+          "DaprResiliencyRetryPolicies"
+        ],
+        "summary": "Get the Dapr Resiliency Retry Policies for a managed environment.",
+        "operationId": "DaprResiliencyRetryPolicies_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyRetryPoliciesCollection"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr Resiliency Retry Policy": {
+            "$ref": "./examples/DaprResiliencyRetryPolicies_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprResiliencyRetryPolicies/{policyName}": {
+      "get": {
+        "tags": [
+          "DaprResiliencyRetryPolicies"
+        ],
+        "summary": "Get a Dapr Resiliency Retry Policy.",
+        "operationId": "DaprResiliencyRetryPolicies_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Name of the Dapr Resiliency Retry Policy.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyRetryPolicy"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr Resiliency Retry Policy": {
+            "$ref": "./examples/DaprResiliencyRetryPolicies_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprResiliencyTimeoutPolicies": {
+      "get": {
+        "tags": [
+          "DaprResiliencyTimeoutPolicies"
+        ],
+        "summary": "Get the Dapr Resiliency Timeout Policies for a managed environment.",
+        "operationId": "DaprResiliencyTimeoutPolicies_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyTimeoutPoliciesCollection"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr Resiliency Timeout Policy": {
+            "$ref": "./examples/DaprResiliencyTimeoutPolicies_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprResiliencyTimeoutPolicies/{policyName}": {
+      "get": {
+        "tags": [
+          "DaprResiliencyTimeoutPolicies"
+        ],
+        "summary": "Get a Dapr Resiliency Timeout Policy.",
+        "operationId": "DaprResiliencyTimeoutPolicies_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Name of the Dapr Resiliency Timeout Policy.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyTimeoutPolicy"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr Resiliency Timeout Policy": {
+            "$ref": "./examples/DaprResiliencyTimeoutPolicies_Get.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DaprResiliencyTimeoutPolicies"
+        ],
+        "summary": "Creates or updates a Dapr Resiliency Timeout Policy.",
+        "description": "Creates or updates a Dapr Resiliency Timeout Policy in a Managed Environment.",
+        "operationId": "DaprResiliencyTimeoutPolicies_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Name of the Dapr Resiliency Timeout Policy.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "name": "daprResiliencyTimeoutPoliciesEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Dapr Resiliency Timeout Policy.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyTimeoutPolicy"
+            }
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyTimeoutPolicy"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/DaprResiliencyTimeoutPolicy"
+            }
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update Dapr Resiliency Timeout Policy": {
+            "$ref": "./examples/DaprResiliencyTimeoutPolicies_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DaprResiliencyTimeoutPolicies"
+        ],
+        "summary": "Delete a Dapr Resiliency Timeout Policy.",
+        "description": "Delete a Dapr Resiliency Timeout Policy from a Managed Environment.",
+        "operationId": "DaprResiliencyTimeoutPolicies_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Name of the Dapr Resiliency Timeout Policy.",
+            "required": true,
+            "pattern": "^.*",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete operation completed"
+          },
+          "204": {
+            "description": "Environment does not exist"
+          },
+          "default": {
+            "description": "Common error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Dapr Resiliency Timeout Policy": {
+            "$ref": "./examples/DaprResiliencyTimeoutPolicies_Delete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DaprResiliencyCircuitBreakerPoliciesCollection": {
+      "description": "Dapr Resiliency Circuit Breaker Policy ARM resource.",
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Collection of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DaprResiliencyCircuitBreakerPolicy"
+          }
+        },
+        "nextLink": {
+          "description": "Link to next page of resources.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "DaprResiliencyCircuitBreakerPolicy": {
+      "description": "Resiliency Policy Circuit Breakers Policy",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "description": "DaprResiliencyCircuitBreakerPolicy resource specific properties",
+          "type": "object",
+          "properties": {
+            "maxRequests": {
+              "description": "Maximum number of requests allowed to pass through",
+              "type": "integer",
+              "format": "int32"
+            },
+            "interval": {
+              "description": "Cyclical period of time used by the CB to clear its internal counts. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            },
+            "timeout": {
+              "description": "The period of the open state until the CB switches to half-open. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            },
+            "trip": {
+              "description": "A Common Expression Language (CEL) statement that is evaluated by the CB When the statement evaluates to true, the CB trips and becomes open",
+              "type": "string"
+            },
+            "circuitBreakerScope": {
+              "description": "Specify whether circuit breaking state should be scoped to an individual actor ID, all actors across the actor type, or both. Possible values include id, type, or both",
+              "type": "string"
+            },
+            "circuitBreakerCacheSize": {
+              "description": "Specify a cache size for the number of CBs to keep in memory. The value should be larger than the expected number of active actor instances.",
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "DaprResiliencyRetryPoliciesCollection": {
+      "description": "Dapr Resiliency Retry Policy ARM resource.",
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Collection of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DaprResiliencyRetryPolicy"
+          }
+        },
+        "nextLink": {
+          "description": "Link to next page of resources.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "DaprResiliencyRetryPolicy": {
+      "description": "Resiliency Policy Retries",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "description": "DaprResiliencyRetryPolicy resource specific properties",
+          "type": "object",
+          "properties": {
+            "policy": {
+              "description": "Back-off and retry interval strategy",
+              "type": "string"
+            },
+            "duration": {
+              "description": "Time interval between retries. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            },
+            "maxRetries": {
+              "description": "The maximum number of retries to attempt. -1 denotes an indefinite number of retries.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "maxInterval": {
+              "description": "Determines the maximum interval between retries. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            }
+          },
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "DaprResiliencyTimeoutPoliciesCollection": {
+      "description": "Dapr Resiliency Timeout Policy ARM resource.",
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Collection of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DaprResiliencyTimeoutPolicy"
+          }
+        },
+        "nextLink": {
+          "description": "Link to next page of resources.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "DaprResiliencyTimeoutPolicy": {
+      "description": "Resiliency Policy Retries",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "description": "DaprResiliencyTimeoutPolicy resource specific properties",
+          "type": "object",
+          "properties": {
+            "general": {
+              "description": "Timeout duration for general operations. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            },
+            "important": {
+              "description": "Timeout duration for important operations. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            },
+            "largeResponse": {
+              "description": "Timeout duration for large operations. Valid values are of the form 15s, 2m, 1h30m, etc.",
+              "type": "string"
+            }
+          },
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ErrorResponse": {
+      "description": "Error response indicates CDN service is not able to process the incoming request. The reason is provided in the error message.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "readOnly": true,
+          "type": "string"
+        }
+      }
+    },
+    "ProxyResource": {
+      "title": "Proxy Resource",
+      "description": "The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a location",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "Resource": {
+      "title": "Resource",
+      "description": "Common fields that are returned in the response for all Azure Resource Manager resources",
+      "type": "object",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\""
+        },
+        "systemData": {
+          "readOnly": true,
+          "type": "object",
+          "description": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+          "$ref": "#/definitions/systemData"
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "DefaultErrorResponse": {
+      "description": "App Service error response.",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "Error model.",
+          "type": "object",
+          "properties": {
+            "code": {
+              "description": "Standardized string to programmatically identify the error.",
+              "type": "string",
+              "readOnly": true
+            },
+            "message": {
+              "description": "Detailed error description and debugging information.",
+              "type": "string",
+              "readOnly": true
+            },
+            "target": {
+              "description": "Detailed error description and debugging information.",
+              "type": "string",
+              "readOnly": true
+            },
+            "details": {
+              "type": "array",
+              "description": "Details or the error",
+              "items": {
+                "description": "Detailed errors.",
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "description": "Standardized string to programmatically identify the error.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "message": {
+                    "description": "Detailed error description and debugging information.",
+                    "type": "string",
+                    "readOnly": true
+                  },
+                  "target": {
+                    "description": "Detailed error description and debugging information.",
+                    "type": "string",
+                    "readOnly": true
+                  }
+                },
+                "readOnly": true
+              },
+              "x-ms-identifiers": [
+                "code"
+              ]
+            },
+            "innererror": {
+              "description": "More information to debug error.",
+              "type": "string",
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "subscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Azure Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "apiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Version of the API to be used with the client request. Current version is 2017-04-02."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_\\-\\(\\)\\.]*[^\\.]$",
+      "minLength": 1,
+      "maxLength": 80,
+      "x-ms-parameter-location": "method",
+      "description": "Name of the Resource group within the Azure subscription."
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
WI: https://msazure.visualstudio.com/One/_workitems/edit/17134173

In https://github.com/Azure/azure-rest-api-specs/pull/22250/checks?check_run_id=11096947098 **_GetCollectionResponseSchema_** is wrongly flagged( it is flagged though the "value" of the collection get and point get are same).

I tried to reproduce the issue locally. However, it worked as expected. 
I tried reproducing all the 3 cases locally and none of them were flagged. I also tried to flip the "value" of the collection get to be different from the point get and noticed that it was flagged.