### PR TITLE
Make ReservedResourceNamesModelAsEnum a warning and correct the path output

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/reserved-resource-names-rule-changes_2023-08-15-19-54.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/reserved-resource-names-rule-changes_2023-08-15-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Change ReservedResourceNamesAsEnum from an error to a warning and make it warn for the path level instead of the operation level",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/reserved-resource-names-rule-changes_2023-08-15-19-54.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/reserved-resource-names-rule-changes_2023-08-15-19-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator-rulesets",
-      "comment": "Change ReservedResourceNamesAsEnum from an error to a warning and make it warn for the path level instead of the operation level",
+      "comment": "Change ReservedResourceNamesAsEnum from an error to a warning and make it warn for the path level instead of the operation level (#575)",
       "type": "patch"
     }
   ],

--- a/docs/reserved-resource-names-model-as-enum.md
+++ b/docs/reserved-resource-names-model-as-enum.md
@@ -2,7 +2,7 @@
 
 ## Category
 
-ARM Error
+ARM Warning
 
 ## Applies to
 

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2372,8 +2372,8 @@ const reservedResourceNamesModelAsEnum = (pathItem, _opts, ctx) => {
     for (const op of INCLUDED_OPERATIONS) {
         if (pathItem[pathName][op]) {
             errors.push({
-                message: `The service-defined (reserved name) resource "${lastPathWord}" must be represented as a path parameter enum with \`modelAsString\` set to \`true\`.`,
-                path: [...path, pathName, op],
+                message: `The service-defined (reserved name) resource "${lastPathWord}" should be represented as a path parameter enum with \`modelAsString\` set to \`true\`.`,
+                path: [...path, pathName],
             });
         }
     }
@@ -3243,9 +3243,9 @@ const ruleset = {
             },
         },
         ReservedResourceNamesModelAsEnum: {
-            description: "Service-defined (reserved) resource names must be represented as an enum type with modelAsString set to true, not as a static string in the path.",
+            description: "Service-defined (reserved) resource names should be represented as an enum type with modelAsString set to true, not as a static string in the path.",
             message: "{{error}}",
-            severity: "error",
+            severity: "warn",
             stagingOnly: true,
             resolved: true,
             formats: [oas2],

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -750,9 +750,9 @@ const ruleset: any = {
     // RPC Code: RPC-ConstrainedCollections-V1-04
     ReservedResourceNamesModelAsEnum: {
       description:
-        "Service-defined (reserved) resource names must be represented as an enum type with modelAsString set to true, not as a static string in the path.",
+        "Service-defined (reserved) resource names should be represented as an enum type with modelAsString set to true, not as a static string in the path.",
       message: "{{error}}",
-      severity: "error",
+      severity: "warning",
       stagingOnly: true,
       resolved: true,
       formats: [oas2],

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -752,7 +752,7 @@ const ruleset: any = {
       description:
         "Service-defined (reserved) resource names should be represented as an enum type with modelAsString set to true, not as a static string in the path.",
       message: "{{error}}",
-      severity: "warning",
+      severity: "warn",
       stagingOnly: true,
       resolved: true,
       formats: [oas2],

--- a/packages/rulesets/src/spectral/functions/reserved-resource-names-model-as-enum.ts
+++ b/packages/rulesets/src/spectral/functions/reserved-resource-names-model-as-enum.ts
@@ -1,4 +1,4 @@
-// Service-defined (reserved) resource names must be represented as an enum type with modelAsString set to true, not as a static string in the path.
+// Service-defined (reserved) resource names should be represented as an enum type with modelAsString set to true, not as a static string in the path.
 // RPC Code: RPC-ConstrainedCollections-V1-04
 
 const ARM_ALLOWED_RESERVED_NAMES = ["operations"]
@@ -33,8 +33,8 @@ export const reservedResourceNamesModelAsEnum = (pathItem: any, _opts: any, ctx:
   for (const op of INCLUDED_OPERATIONS) {
     if (pathItem[pathName][op]) {
       errors.push({
-        message: `The service-defined (reserved name) resource "${lastPathWord}" must be represented as a path parameter enum with \`modelAsString\` set to \`true\`.`,
-        path: [...path, pathName, op],
+        message: `The service-defined (reserved name) resource "${lastPathWord}" should be represented as a path parameter enum with \`modelAsString\` set to \`true\`.`,
+        path: [...path, pathName],
       })
     }
   }

--- a/packages/rulesets/src/spectral/test/reserved-resource-names-model-as-enum.test.ts
+++ b/packages/rulesets/src/spectral/test/reserved-resource-names-model-as-enum.test.ts
@@ -29,13 +29,13 @@ test("ReservedResourceNamesAsEnum should find errors on path level", () => {
       "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/fooName.get"
     )
     expect(results[0].message).toBe(
-      'The service-defined (reserved name) resource "fooName" must be represented as a path parameter enum with `modelAsString` set to `true`.'
+      'The service-defined (reserved name) resource "fooName" should be represented as a path parameter enum with `modelAsString` set to `true`.'
     )
     expect(results[1].path.join(".")).toBe(
       "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/fooName.put"
     )
     expect(results[1].message).toBe(
-      'The service-defined (reserved name) resource "fooName" must be represented as a path parameter enum with `modelAsString` set to `true`.'
+      'The service-defined (reserved name) resource "fooName" should be represented as a path parameter enum with `modelAsString` set to `true`.'
     )
   })
 })

--- a/packages/rulesets/src/spectral/test/reserved-resource-names-model-as-enum.test.ts
+++ b/packages/rulesets/src/spectral/test/reserved-resource-names-model-as-enum.test.ts
@@ -105,3 +105,27 @@ test("ReservedResourceNamesAsEnum should find no errors for 'operations' endpoin
     expect(results.length).toBe(0)
   })
 })
+
+test("ReservedResourceNamesAsEnum should find errors for 'default' endpoint", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/default": {
+        parameters: [],
+        get: {
+          parameters: [],
+          responses: {},
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(1)
+    expect(results[0].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/default"
+    )
+    expect(results[0].message).toBe(
+      'The service-defined (reserved name) resource "default" should be represented as a path parameter enum with `modelAsString` set to `true`.'
+    )
+  })
+})

--- a/packages/rulesets/src/spectral/test/reserved-resource-names-model-as-enum.test.ts
+++ b/packages/rulesets/src/spectral/test/reserved-resource-names-model-as-enum.test.ts
@@ -24,17 +24,11 @@ test("ReservedResourceNamesAsEnum should find errors on path level", () => {
     },
   }
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(2)
+    expect(results.length).toBe(1)
     expect(results[0].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/fooName.get"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/fooName"
     )
     expect(results[0].message).toBe(
-      'The service-defined (reserved name) resource "fooName" should be represented as a path parameter enum with `modelAsString` set to `true`.'
-    )
-    expect(results[1].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/foos/fooName.put"
-    )
-    expect(results[1].message).toBe(
       'The service-defined (reserved name) resource "fooName" should be represented as a path parameter enum with `modelAsString` set to `true`.'
     )
   })


### PR DESCRIPTION
[ADO PBI 24837788](https://msazure.visualstudio.com/One/_workitems/edit/24837788)

- Correct the output path. Currently pointing to, e.g., `paths./path/.get` but should point to `paths./path/`
- Make it a warning instead of an error