### PR TITLE
Fix doc for LatestVersionOfCommonTypesMustBeUsed

### DIFF
--- a/docs/latest-version-of-common-types-must-be-used.md
+++ b/docs/latest-version-of-common-types-must-be-used.md
@@ -2,7 +2,7 @@
 
 ## Category
 
-ARM Error
+ARM Warning
 
 ## Applies to
 
@@ -12,7 +12,7 @@ ARM OpenAPI (swagger) specs
 
 Use the latest version {0} of {1} available under common-types.
 
-## Description.
+## Description
 
 This rule checks for references that aren't using the latest version of common-types.
 


### PR DESCRIPTION
[ADO Task link](https://msazure.visualstudio.com/One/_workitems/edit/24837939)

This is currently a warning:

https://github.com/Azure/azure-openapi-validator/blob/main/packages/rulesets/src/spectral/az-arm.ts#L806C17-L806C17

Should be ARM warning in the doc, not ARM error.