### PR TITLE
Correct path for OperationsApiTenantLevelOnly

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/correct-path-operations-api-tenant-level_2023-08-15-20-46.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/correct-path-operations-api-tenant-level_2023-08-15-20-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator-rulesets",
-      "comment": "Change OperationsApiTenantLevelOnly to error for the path level instead of the operation level",
+      "comment": "Change OperationsApiTenantLevelOnly to error for the path level instead of the operation level (#577)",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/correct-path-operations-api-tenant-level_2023-08-15-20-46.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/correct-path-operations-api-tenant-level_2023-08-15-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Change OperationsApiTenantLevelOnly to error for the path level instead of the operation level",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1832,7 +1832,7 @@ const operationsApiTenantLevelOnly = (pathItem, _opts, ctx) => {
         if (pathItem[pathName][GET] && pathName.toString().endsWith(OPERATIONS) && pathName.match(NOT_TENANT_LEVEL_REGEX)) {
             errors.push({
                 message: "The get operations endpoint for the operations API must only be at the tenant level.",
-                path: [...path, pathName, GET],
+                path: [...path, pathName],
             });
         }
     }

--- a/packages/rulesets/src/spectral/functions/operations-api-tenant-level-only.ts
+++ b/packages/rulesets/src/spectral/functions/operations-api-tenant-level-only.ts
@@ -26,7 +26,7 @@ export const operationsApiTenantLevelOnly = (pathItem: any, _opts: any, ctx: any
     if (pathItem[pathName][GET] && pathName.toString().endsWith(OPERATIONS) && pathName.match(NOT_TENANT_LEVEL_REGEX)) {
       errors.push({
         message: "The get operations endpoint for the operations API must only be at the tenant level.",
-        path: [...path, pathName, GET],
+        path: [...path, pathName],
       })
     }
   }

--- a/packages/rulesets/src/spectral/test/operations-api-tenant-level-only.test.ts
+++ b/packages/rulesets/src/spectral/test/operations-api-tenant-level-only.test.ts
@@ -45,10 +45,10 @@ test("OperationsApiTenantLevelOnly should find errors", () => {
   return linter.run(oasDoc).then((results) => {
     expect(results.length).toBe(2)
     expect(results[0].message).toBe(ERROR_MESSAGE)
-    expect(results[0].path.join(".")).toBe("paths./subscriptions/{subscriptionId}/providers/Microsoft.LoadTestService/operations.get")
+    expect(results[0].path.join(".")).toBe("paths./subscriptions/{subscriptionId}/providers/Microsoft.LoadTestService/operations")
     expect(results[1].message).toBe(ERROR_MESSAGE)
     expect(results[1].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.LoadTestService/operations.get"
+      "paths./subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.LoadTestService/operations"
     )
   })
 })


### PR DESCRIPTION
[ADO Task link](https://msazure.visualstudio.com/One/_workitems/edit/24837897)

Currently it outputs, e.g., `paths./path/.get` but should output `paths./path/`.
