### PR TITLE
Fix documentation link for AzureResourceTagsSchema rule

### DIFF
--- a/docs/azure-resource-tags-schema.md
+++ b/docs/azure-resource-tags-schema.md
@@ -1,4 +1,4 @@
-# AzureResourceTagsSchemaValidation
+# AzureResourceTagsSchema
 
 ## Category
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -116,11 +116,11 @@ Nested properties can result into bad user experience especially when creating r
 
 Please refer to [avoid-nested-properties.md](./avoid-nested-properties.md) for details.
 
-### AzureResourceTagsSchemaValidation
+### AzureResourceTagsSchema
 
 This rule is to check if the tags definition of a resource conforms to the common tags definition.
 
-Please refer to [azure-resource-tags-schema-validation.md](./azure-resource-tags-schema-validation.md) for details.
+Please refer to [azure-resource-tags-schema.md](./azure-resource-tags-schema.md) for details.
 
 ### BodyPropertiesNamesCamelCase
 


### PR DESCRIPTION
The documentation link for AzureResourceTagsSchema rule is broken. This PR fixes it.