### PR TITLE
Fix severity of the PatchSkuProperty and PatchIdentityProperty rules to warning

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fixSeverityForPatchOperations_2023-08-16-06-54.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fixSeverityForPatchOperations_2023-08-16-06-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Change severity of PatchSkuProperty and PatchIdentityProperty to warning",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/patch-identity-property.md
+++ b/docs/patch-identity-property.md
@@ -2,7 +2,7 @@
 
 ## Category
 
-ARM Error
+ARM Warning
 
 ## Applies to
 
@@ -14,11 +14,11 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-The patch operation body parameter schema should contains property 'identity'.
+The patch operation body parameter schema should contain property 'identity' if the service allows it to be updated.
 
 ## Description
 
-RP must implement PATCH for the 'identity' envelope property if it's defined in the resource model.
+RP should consider implementing Patch for the 'identity' envelope property if it's defined in the resource model. You may ignore this violation if your service does not allow updation of the identity property once it is set. In such a case the property must be marked with x-ms-mutability [create, read]
 
 ## CreatedAt
 

--- a/docs/patch-sku-property.md
+++ b/docs/patch-sku-property.md
@@ -2,7 +2,7 @@
 
 ## Category
 
-ARM Error
+ARM Warning
 
 ## Applies to
 
@@ -14,11 +14,11 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-The patch operation body parameter schema should contain property 'sku'.
+The patch operation body parameter schema should contain property 'sku' if the service supports updation of the property.
 
 ## Description
 
-RP must implement PATCH for the 'SKU' envelope property if it's defined in the resource model.
+RP should consider implementing Patch for the 'SKU' envelope property if it's defined in the resource model. You may ignore this violation if your service does not allow updation of the Sku property once it is set. In such a case the property must be marked with x-ms-mutability [create, read]
 
 ## CreatedAt
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -757,7 +757,7 @@ Please refer to [patch-content-type.md](./patch-content-type.md) for details.
 
 ### PatchIdentityProperty
 
-RP must implement PATCH for the 'identity' envelope property if it's defined in the resource model.
+RP should consider implementing Patch for the 'identity' envelope property if it's defined in the resource model. You may ignore this violation if your service does not allow updation of the identity property once it is set. In such a case the property must be marked with x-ms-mutability [create, read]
 
 Please refer to [patch-identity-property.md](./patch-identity-property.md) for details.
 
@@ -781,7 +781,7 @@ Please refer to [patch-response-codes.md](./patch-response-codes.md) for details
 
 ### PatchSkuProperty
 
-RP must implement PATCH for the 'SKU' envelope property if it's defined in the resource model.
+RP should consider implementing Patch for the 'SKU' envelope property if it's defined in the resource model. You may ignore this violation if your service does not allow updation of the Sku property once it is set. In such a case the property must be marked with x-ms-mutability [create, read]
 
 Please refer to [patch-sku-property.md](./patch-sku-property.md) for details.
 

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2621,7 +2621,7 @@ const validatePatchBodyParamProperties = createRulesetFunction({
     if (bodyParameter) {
         const index = patchOp.parameters.findIndex((p) => p.in === "body");
         if (_opts.should) {
-            const responseSchema = ((_d = (_c = patchOp.responses) === null || _c === void 0 ? void 0 : _c["200"]) === null || _d === void 0 ? void 0 : _d.schema) || ((_f = (_e = patchOp.responses) === null || _e === void 0 ? void 0 : _e["201"]) === null || _f === void 0 ? void 0 : _f.schema) || getGetOperationSchema(path.slice(0, -1), ctx);
+            const responseSchema = ((_d = (_c = patchOp.responses) === null || _c === void 0 ? void 0 : _c["200"]) === null || _d === void 0 ? void 0 : _d.schema) || ((_f = (_e = patchOp.responses) === null || _e === void 0 ? void 0 : _e["202"]) === null || _f === void 0 ? void 0 : _f.schema) || getGetOperationSchema(path.slice(0, -1), ctx);
             _opts.should.forEach((p) => {
                 var _a, _b;
                 if (!((_a = getProperties(bodyParameter)) === null || _a === void 0 ? void 0 : _a[p]) && ((_b = getProperties(responseSchema)) === null || _b === void 0 ? void 0 : _b[p])) {
@@ -2951,9 +2951,9 @@ const ruleset = {
             },
         },
         PatchSkuProperty: {
-            description: "RP must implement PATCH for the 'SKU' envelope property if it's defined in the resource model.",
+            description: "RP should consider implementing Patch for the 'SKU' envelope property if it's defined in the resource model and the service supports its updation.",
             message: "{{error}}",
-            severity: "error",
+            severity: "warn",
             resolved: true,
             formats: [oas2],
             given: ["$[paths,'x-ms-paths'].*.patch"],

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -400,9 +400,10 @@ const ruleset: any = {
     },
     // RPC Code: RPC-Patch-V1-09
     PatchSkuProperty: {
-      description: "RP must implement PATCH for the 'SKU' envelope property if it's defined in the resource model.",
+      description:
+        "RP should consider implementing Patch for the 'SKU' envelope property if it's defined in the resource model and the service supports its updation.",
       message: "{{error}}",
-      severity: "error",
+      severity: "warn",
       resolved: true,
       formats: [oas2],
       given: ["$[paths,'x-ms-paths'].*.patch"],

--- a/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
+++ b/packages/rulesets/src/spectral/functions/validate-patch-body-param-properties.ts
@@ -42,7 +42,7 @@ export const validatePatchBodyParamProperties = createRulesetFunction<unknown, O
       const index = patchOp.parameters.findIndex((p: any) => p.in === "body")
       if (_opts.should) {
         const responseSchema =
-          patchOp.responses?.["200"]?.schema || patchOp.responses?.["201"]?.schema || getGetOperationSchema(path.slice(0, -1), ctx)
+          patchOp.responses?.["200"]?.schema || patchOp.responses?.["202"]?.schema || getGetOperationSchema(path.slice(0, -1), ctx)
         _opts.should.forEach((p: string) => {
           if (!getProperties(bodyParameter)?.[p] && getProperties(responseSchema)?.[p]) {
             errors.push({


### PR DESCRIPTION
There are some services that do not allow the Sku and identity property to be updated once it is set, so this rule should just be a warning.