### PR TITLE
Add non fully qualified paths extension resource reg to be excluded f…

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-ListBySubscriptionForExtensionResourceFalsePositive_2023-08-22-22-01.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-ListBySubscriptionForExtensionResourceFalsePositive_2023-08-22-22-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "update extensionResourceRegex to also include unqualified paths",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-ListBySubscriptionForExtensionResourceFalsePositive_2023-08-22-22-01.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-ListBySubscriptionForExtensionResourceFalsePositive_2023-08-22-22-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator-rulesets",
-      "comment": "update extensionResourceRegex to also include unqualified paths",
+      "comment": "Exclude not fully qualified extension resource paths in TopLevelResourcesListBySubscription linter rule",
       "type": "patch"
     }
   ],

--- a/packages/rulesets/src/native/tests/arm-utils-tests.ts
+++ b/packages/rulesets/src/native/tests/arm-utils-tests.ts
@@ -25,7 +25,7 @@ describe("ArmHelperTests", () => {
 
     assert.equal(allNestedResource.length, 8)
     assert.equal(allTopLevelResource.length, 13)
-    assert.equal(allCollectionInfo.length, 23)
-    assert.equal(allCollectionModel.size, 21)
+    assert.equal(allCollectionInfo.length, 24)
+    assert.equal(allCollectionModel.size, 22)
   })
 })

--- a/packages/rulesets/src/native/tests/resources/armResource/compute.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/compute.json
@@ -65,6 +65,150 @@
         ]
       }
     },
+    "/{resourceUri}/providers/Microsoft.EdgeProvisioning/deviceProvisioningStates": {
+      "get": {
+        "operationId": "DeviceProvisioningStates_List",
+        "tags": [
+          "DeviceProvisioningStates"
+        ],
+        "description": "List DeviceProvisioningState resources by parent",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Client Api Version.",
+            "enum": [
+              "2020-06-01"
+            ]
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeviceProvisioningStateListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": null,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.EdgeProvisioning/deviceProvisioningStates/default": {
+      "get": {
+        "operationId": "DeviceProvisioningStates_Get",
+        "tags": [
+          "DeviceProvisioningStates"
+        ],
+        "description": "Get a DeviceProvisioningState",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Client Api Version.",
+            "enum": [
+              "2020-06-01"
+            ]
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeviceProvisioningState"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": null
+      },
+      "put": {
+        "operationId": "DeviceProvisioningStates_CreateOrUpdate",
+        "tags": [
+          "DeviceProvisioningStates"
+        ],
+        "description": "Create a DeviceProvisioningState",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Client Api Version.",
+            "enum": [
+              "2020-06-01"
+            ]
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DeviceProvisioningState"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource create or update operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeviceProvisioningState"
+            }
+          },
+          "201": {
+            "description": "ARM create operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeviceProvisioningState"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": null,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}": {
       "put": {
         "tags": [
@@ -11470,6 +11614,52 @@
     }
   },
   "definitions": {
+    "ErrorResponse": {
+      "title": "Error response",
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "The error object."
+        }
+      }
+    },
+    "DeviceProvisioningState": {
+      "type": "object",
+      "description": "The provisioning state of a device.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DeviceProvisioningStateProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "DeviceProvisioningStateListResult": {
+      "type": "object",
+      "description": "The response of a DeviceProvisioningState list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DeviceProvisioningState items on this page",
+          "items": {
+            "$ref": "#/definitions/DeviceProvisioningState"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
     "ComputeOperationListResult": {
       "properties": {
         "value": {
@@ -19532,6 +19722,15 @@
     }
   },
   "parameters": {
+    "Azure.ResourceManager.ResourceUriParameter": {
+      "name": "resourceUri",
+      "in": "path",
+      "description": "The fully qualified Azure Resource manager identifier of the resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
     "SubscriptionIdParameter": {
       "name": "subscriptionId",
       "in": "path",

--- a/packages/rulesets/src/native/utilities/arm-helper.ts
+++ b/packages/rulesets/src/native/utilities/arm-helper.ts
@@ -56,7 +56,7 @@ export class ArmHelper {
   private SpecificResourcePathRegEx = new RegExp("/providers/[^/]+(?:/\\w+/default|/\\w+/{[^/]+})+$", "gi")
 
   private ExtensionResourceFullyQualifiedPathReg = new RegExp(".+/providers/.+/providers/.+$", "gi")
-  private ExtensionResourceReg = new RegExp("^\/{", "gi")
+  private ExtensionResourceReg = new RegExp("^/{", "gi")
 
   //  resource model with 'x-ms-resource' or allOfing 'Resource' or 'TrackedResource' for ProxyResource
   private XmsResources = new Set<string>()

--- a/packages/rulesets/src/native/utilities/arm-helper.ts
+++ b/packages/rulesets/src/native/utilities/arm-helper.ts
@@ -55,7 +55,9 @@ export class ArmHelper {
 
   private SpecificResourcePathRegEx = new RegExp("/providers/[^/]+(?:/\\w+/default|/\\w+/{[^/]+})+$", "gi")
 
-  private ExtensionResourceReg = new RegExp(".+/providers/.+/providers/.+$", "gi")
+  private ExtensionResourceFullyQualifiedPathReg = new RegExp(".+/providers/.+/providers/.+$", "gi")
+  private ExtensionResourceReg = new RegExp("^\/{", "gi")
+
   //  resource model with 'x-ms-resource' or allOfing 'Resource' or 'TrackedResource' for ProxyResource
   private XmsResources = new Set<string>()
   resources: ResourceInfo[] = []
@@ -567,7 +569,7 @@ export class ArmHelper {
   }
 
   public isPathOfExtensionResource(path: string) {
-    return !!path.match(this.ExtensionResourceReg)
+    return !!path.match(this.ExtensionResourceFullyQualifiedPathReg) || !!path.match(this.ExtensionResourceReg)
   }
 
   /**

--- a/packages/rulesets/src/native/utilities/arm-helper.ts
+++ b/packages/rulesets/src/native/utilities/arm-helper.ts
@@ -56,7 +56,7 @@ export class ArmHelper {
   private SpecificResourcePathRegEx = new RegExp("/providers/[^/]+(?:/\\w+/default|/\\w+/{[^/]+})+$", "gi")
 
   private ExtensionResourceFullyQualifiedPathReg = new RegExp(".+/providers/.+/providers/.+$", "gi")
-  private ExtensionResourceReg = new RegExp("^/{", "gi")
+  private ExtensionResourceReg = new RegExp("^/{\\w+}/providers/.+$", "gi")
 
   //  resource model with 'x-ms-resource' or allOfing 'Resource' or 'TrackedResource' for ProxyResource
   private XmsResources = new Set<string>()


### PR DESCRIPTION
TopLevelResourcesListBySubscription rules checks if all the top-level resources have list by subscription defined (i.e, subscription level get call should exist for all the top-level resources)
Toay the logic doesn't account for the unqualified extension resources. Update the ExtensionResourceReg to consider the  unqualified extension resource paths and exclude them from being considered while building the topLevelResources