### PR TITLE
Added new rule to check ASYNC headers and x-ms-long-running-operation property

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-xmsLongRunningOperation_2023-09-01-23-32.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-xmsLongRunningOperation_2023-09-01-23-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Add XmsLongRunningOperationProperty as new rule. This rules checks if any reponses headers have Location or Azure-AsyncOperation properties, then it must have x-ms-long-running-operation set to true.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1320,6 +1320,12 @@ This rule is to check the `id` property or identifier of objects in the array. S
 
 Please refer to [xms-identifier-validation.md](./xms-identifier-validation.md) for details.
 
+### XmsLongRunningOperationProperty
+
+If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`.
+
+Please refer to [xms-long-running-operation-property.md](./xms-long-running-operation-property.md) for details.
+
 ### XmsPageableListByRGAndSubscriptions
 
 When a tracked resource has list by resource group and subscription operations, the x-ms-pageable extension values must be same for both operations. A tracked resource is a resource with a 'location' property as required. If this rule flags a resource which does not have a 'location' property, then it might be a false positive.

--- a/docs/xms-long-running-operation-property.md
+++ b/docs/xms-long-running-operation-property.md
@@ -1,0 +1,67 @@
+# XmsLongRunningOperationProperty
+
+## Category
+
+ARM Error
+
+## Applies to
+
+ARM OpenAPI(swagger) specs
+
+## Related ARM Guideline Code
+
+- RPC-Async-V1-15
+
+## Output Message
+
+If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`.
+
+## Description
+
+If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`.
+
+## How to fix the violation
+
+You can do either of the following:
+- Set the property `x-ms-long-running-operation` to `true`.
+- If `x-ms-long-running-operation` is set to `false` then remove `Location` and `Azure-AsyncOperation` headers from the response.
+
+### Valid Examples
+
+If you want `headers` to be included in the `responses` that is considered as ASYNC call, then you must set `x-ms-long-running-operation : true` as below example
+
+```json
+...
+// responses with headers
+"responses": {
+    "2XX": {
+      "description": "Async call",
+      "headers": {
+        "Azure-AsyncOperation": {
+          "type": "string",
+        },
+        "Location": {
+          "type": "string",
+        },
+      },
+    },
+  },
+// set this property as true
+"x-ms-long-running-operation": true
+...
+```
+
+The following would be valid for SYNC calls:
+
+```json
+...
+// responses with No headers
+"responses": {
+    "2xx": {
+      "description": "sync call",
+      // No headers
+    }
+  },
+"x-ms-long-running-operation": false
+...
+```

--- a/docs/xms-long-running-operation-property.md
+++ b/docs/xms-long-running-operation-property.md
@@ -23,8 +23,8 @@ If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-As
 ## How to fix the violation
 
 You can do either of the following:
-- Set the property `x-ms-long-running-operation` to `true`.
-- If `x-ms-long-running-operation` is set to `false` then remove `Location` and `Azure-AsyncOperation` headers from the response.
+- If the operation is intended to be a long running operation, set the property `x-ms-long-running-operation` to `true`.
+- If the operation is not intended to be a long running operation, `x-ms-long-running-operation` MUST be set to `false` and the `Location` and `Azure-AsyncOperation` headers MUST not be specified in the response.
 
 ### Valid Examples
 

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -48,6 +48,7 @@ import { systemDataInPropertiesBag } from "./functions/system-data-in-properties
 import trackedResourceTagsPropertyInRequest from "./functions/trackedresource-tags-property-in-request"
 import { validatePatchBodyParamProperties } from "./functions/validate-patch-body-param-properties"
 import withXmsResource from "./functions/with-xms-resource"
+import verifyXMSLongRunningOperationProperty from "./functions/xms-long-running-operation-property"
 const ruleset: any = {
   extends: [common],
   rules: {
@@ -164,6 +165,21 @@ const ruleset: any = {
       given: ["$[paths,'x-ms-paths'].*[post]"],
       then: {
         function: PostResponseCodes,
+      },
+    },
+
+    // RPC Code: RPC-Async-V1-15
+    XMSLongRunningOperationProperty: {
+      description:
+        "If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`",
+      message:
+        "If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`",
+      severity: "error",
+      formats: [oas2],
+      resolved: true,
+      given: "$[paths,'x-ms-paths'].*[put,patch,post,delete]",
+      then: {
+        function: verifyXMSLongRunningOperationProperty,
       },
     },
 

--- a/packages/rulesets/src/spectral/functions/xms-long-running-operation-property.ts
+++ b/packages/rulesets/src/spectral/functions/xms-long-running-operation-property.ts
@@ -1,0 +1,30 @@
+// RPC Code: RPC-Async-V1-15
+
+const errorMessage =
+  "If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`"
+const responsesCodes = ["200", "201", "202", "204"]
+
+const verifyXMSLongRunningOperationProperty = (pathItem: any, _opts: any, paths: any) => {
+  if (pathItem === null || typeof pathItem !== "object" || pathItem["x-ms-long-running-operation"] === true) {
+    return []
+  }
+  const path = paths.path || []
+
+  for (const code of responsesCodes) {
+    const headers = pathItem.responses[code]?.headers
+    if (headers) {
+      for (const headerValue of Object.keys(headers)) {
+        if (headerValue.toLowerCase() === "location" || headerValue.toLowerCase() === "azure-asyncoperation") {
+          return [
+            {
+              message: errorMessage,
+              path: path.concat(["responses", code, "headers", headerValue]),
+            },
+          ]
+        }
+      }
+    }
+  }
+  return
+}
+export default verifyXMSLongRunningOperationProperty

--- a/packages/rulesets/src/spectral/test/xms-long-running-operation-property.test.ts
+++ b/packages/rulesets/src/spectral/test/xms-long-running-operation-property.test.ts
@@ -1,0 +1,172 @@
+import { Spectral } from "@stoplight/spectral-core"
+import linterForRule from "./utils"
+
+let linter: Spectral
+
+const errorMessage =
+  "If an operation's (PUT/POST/PATCH/DELETE) responses have `Location` or `Azure-AsyncOperation` headers then it MUST have the property `x-ms-long-running-operation` set to `true`"
+
+beforeAll(async () => {
+  linter = await linterForRule("XMSLongRunningOperationProperty")
+  return linter
+})
+
+test("XMSLongRunningOperationProperty should find errors", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/api/Paths": {
+        put: {
+          responses: {
+            201: {
+              description: "Put call with two headers and no x-ms-long-running-operation.",
+              headers: {
+                "Azure-AsyncOperation": {
+                  type: "string",
+                },
+                Location: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+        patch: {
+          responses: {
+            201: {
+              description: "Success",
+            },
+            202: {
+              description: "Patch call with two headers and x-ms-long-running-operation set to false.",
+              headers: {
+                "azure-Asyncoperation": {
+                  type: "string",
+                },
+                Location: {
+                  type: "string",
+                },
+              },
+            },
+          },
+          "x-ms-pageable": {
+            nextLinkName: null,
+          },
+          "x-ms-long-running-operation": false,
+        },
+        post: {
+          description: "post call",
+          responses: {
+            "200": {
+              headers: {
+                Location: {
+                  type: "string",
+                  description: "Post call with Location header and no x-ms-long-running-operation.",
+                },
+              },
+            },
+            "404": {
+              description: "Not found.",
+              "x-ms-error-response": true,
+            },
+          },
+        },
+        delete: {
+          description: "delete call",
+          responses: {
+            "202": {
+              headers: {
+                "azure-asyncOperation": {
+                  type: "string",
+                  description: "Delete call with Azure-AsyncOperation header and no x-ms-long-running-operation.",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(4)
+    expect(results[0].path.join(".")).toBe("paths./api/Paths.put.responses.201.headers.Azure-AsyncOperation")
+    expect(results[1].path.join(".")).toBe("paths./api/Paths.patch.responses.202.headers.azure-Asyncoperation")
+    expect(results[2].path.join(".")).toBe("paths./api/Paths.post.responses.200.headers.Location")
+    expect(results[3].path.join(".")).toBe("paths./api/Paths.delete.responses.202.headers.azure-asyncOperation")
+    expect(results[0].message).toBe(errorMessage)
+    expect(results[1].message).toBe(errorMessage)
+    expect(results[2].message).toBe(errorMessage)
+    expect(results[3].message).toBe(errorMessage)
+  })
+})
+
+test("XMSLongRunningOperationProperty should find no errors", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/api/Paths": {
+        put: {
+          responses: {
+            201: {
+              description: "Put call with Azure-AsyncOperation header and x-ms-long-running-operation set to true",
+              headers: {
+                "azure-Asyncoperation": {
+                  type: "string",
+                },
+              },
+            },
+          },
+          "x-ms-long-running-operation": true,
+        },
+        patch: {
+          responses: {
+            201: {
+              description: "Success",
+            },
+            202: {
+              description: "Patch call with both headers and x-ms-long-running-operation set to true.",
+              headers: {
+                "azure-Asyncoperation": {
+                  type: "string",
+                },
+                Location: {
+                  type: "string",
+                },
+              },
+            },
+          },
+          "x-ms-long-running-operation": true,
+        },
+        post: {
+          responses: {
+            "200": {
+              headers: {
+                Location: {
+                  type: "string",
+                  description: "Post call with Location header and x-ms-long-running-operation set to true.",
+                },
+              },
+            },
+            "404": {
+              description: "Not found.",
+              "x-ms-error-response": true,
+            },
+          },
+          "x-ms-long-running-operation": true,
+        },
+        delete: {
+          description: "Delete call with no headers and x-ms-long-running-operation set to false.",
+          responses: {
+            "200": {
+              type: "object",
+            },
+          },
+        },
+        "x-ms-long-running-operation": false,
+      },
+    },
+  }
+
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
If responses have headers 'Location' or 'Azure-AsyncOperation', the then Async operations must set 'x-ms-long-running-operation' property set to 'true'