### PR TITLE
Add test cases for path-for-resource-action linter rule

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-implement_rpc_post_v1_07_2023-09-08-00-26.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-implement_rpc_post_v1_07_2023-09-08-00-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Add test cases for path-for-resource-action rule",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/path-for-resource-action.md
+++ b/docs/path-for-resource-action.md
@@ -30,8 +30,15 @@ June 21, 2022
 
 ## How to fix the violation
 
-Fix the path for resource action as follow below pattern:
+Fix the path for resource action as one of the following patterns:
+
+```json
+"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MyNameSpace/Action"
+```
 
 ```json
 "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MyNameSpace/MyResourceType/{Name}/Action"
+
+```json
+"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MyNameSpace/MyResourceType/{Name}/nestedResourceType/{nestedResourceName}/Action"
 ```

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -704,7 +704,7 @@ const ruleset: any = {
         },
       },
     },
-    // RPC Code: RPC-Uri-V1-07, RPC-POST-V1-01
+    // RPC Code: RPC-Uri-V1-07, RPC-POST-V1-01, RPC-POST-V1-07
     PathForResourceAction: {
       description: "Path for 'post' method on a resource type MUST follow valid resource naming.",
       message: "{{description}}",

--- a/packages/rulesets/src/spectral/test/arm-path-validation.test.ts
+++ b/packages/rulesets/src/spectral/test/arm-path-validation.test.ts
@@ -467,6 +467,36 @@ test("PathForResourceAction should find errors for invalid path and no errors fo
   const oasDoc = {
     swagger: "2.0",
     paths: {
+      //valid uri's
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/addSong": {
+        post: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/addSong": {
+        post: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/{artistName}/addArtistName":
+        {
+          post: {
+            tags: ["SampleTag"],
+            operationId: "Foo_CreateOrUpdate",
+            description: "Test Description",
+            parameters: [],
+            responses: {},
+          },
+        },
+      //invalid uri's
       "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music": {
         post: {
           tags: ["SampleTag"],
@@ -485,7 +515,7 @@ test("PathForResourceAction should find errors for invalid path and no errors fo
           responses: {},
         },
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/addSong": {
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/addSong": {
         post: {
           tags: ["SampleTag"],
           operationId: "Foo_CreateOrUpdate",
@@ -494,10 +524,20 @@ test("PathForResourceAction should find errors for invalid path and no errors fo
           responses: {},
         },
       },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/addArtistName":
+        {
+          post: {
+            tags: ["SampleTag"],
+            operationId: "Foo_CreateOrUpdate",
+            description: "Test Description",
+            parameters: [],
+            responses: {},
+          },
+        },
     },
   }
   return linters.PathForResourceAction.run(oasDoc).then((results) => {
-    expect(results.length).toBe(2)
+    expect(results.length).toBe(4)
     expect(results[0].path.join(".")).toBe(
       "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music"
     )
@@ -506,6 +546,14 @@ test("PathForResourceAction should find errors for invalid path and no errors fo
       "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}"
     )
     expect(results[1].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
+    expect(results[2].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/addSong"
+    )
+    expect(results[2].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
+    expect(results[3].path.join(".")).toBe(
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/addArtistName"
+    )
+    expect(results[3].message).toContain("Path for 'post' method on a resource type MUST follow valid resource naming.")
   })
 })
 


### PR DESCRIPTION
RPC-POST-V1-07 rule is already covered by PathForResourceAction linter rule
Added more tests to verify if the rule satisfies all the cases in RPC-POST-V1-07