### PR TITLE
Fix invalid cycle error when a swagger references itself

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-core/FixDirectCycleIssue_2023-10-10-01-12.json
+++ b/common/changes/@microsoft.azure/openapi-validator-core/FixDirectCycleIssue_2023-10-10-01-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-core",
+      "comment": "Fix invalid self-dependency cycle bug",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-core"
+}

--- a/packages/azure-openapi-validator/core/package.json
+++ b/packages/azure-openapi-validator/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/azure-openapi-validator/core/src/swaggerInventory.ts
+++ b/packages/azure-openapi-validator/core/src/swaggerInventory.ts
@@ -76,7 +76,11 @@ export class SwaggerInventory implements ISwaggerInventory {
         this.inventory.addNode(ref)
         await this.cacheDocument(ref)
       }
-      this.inventory.addDependency(specPath, ref)
+      // If a spec references itself we don't need to add it as a dependency and
+      // cause the dependency graph to fail because it thinks there is a cycle.
+      if (specPath != ref) {
+        this.inventory.addDependency(specPath, ref)
+      }
     }
     return document
   }


### PR DESCRIPTION
While building our file cache we were trying to add ourself to the list of dependencies which gets detected as a cycle and causes a "Dependency Cycle Found" error. This error has been there for a long time but it wasn't really noticed until we recently started having fatal errors break the validation in PR https://dev.azure.com/devdiv/DevDiv/_git/openapi-alps/pullrequest/501030.

The fix simply stops adding self references as a dependency in the graph.

This fixes error messages similar to:
openapiValidatorPluginFunc: Failed validating:Error: Dependency Cycle Found: file:///mnt/vss/_work/1/azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimanagement.json -> file:///mnt/vss/_work/1/azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/definitions.json -> file:///mnt/vss/_work/1/azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/definitions.json