### PR TITLE
Enable circular dependencies

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-core/FixDirectCycleIssue_2023-10-10-21-39.json
+++ b/common/changes/@microsoft.azure/openapi-validator-core/FixDirectCycleIssue_2023-10-10-21-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-core",
+      "comment": "Enable Dependency Cycles in the openapi documents",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-core"
+}

--- a/packages/azure-openapi-validator/core/package.json
+++ b/packages/azure-openapi-validator/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/azure-openapi-validator/core/src/swaggerInventory.ts
+++ b/packages/azure-openapi-validator/core/src/swaggerInventory.ts
@@ -5,7 +5,7 @@ import { ISwaggerInventory, IFileSystem } from "./types"
 import { defaultFileSystem, normalizePath } from "./utils"
 const DepGraph = require("dependency-graph").DepGraph
 export class SwaggerInventory implements ISwaggerInventory {
-  private inventory = new DepGraph()
+  private inventory = new DepGraph({ circular: true })
   private referenceCache = new Map<string, OpenapiDocument>()
   private allDocs = new Map<string, any>()
   private docRecords: Record<string, any> | undefined = undefined
@@ -76,11 +76,7 @@ export class SwaggerInventory implements ISwaggerInventory {
         this.inventory.addNode(ref)
         await this.cacheDocument(ref)
       }
-      // If a spec references itself we don't need to add it as a dependency and
-      // cause the dependency graph to fail because it thinks there is a cycle.
-      if (specPath != ref) {
-        this.inventory.addDependency(specPath, ref)
-      }
+      this.inventory.addDependency(specPath, ref)
     }
     return document
   }


### PR DESCRIPTION
Second attempt to fix the circular dependency error. https://github.com/Azure/azure-openapi-validator/pull/607

This fixes error messages similar to:
openapiValidatorPluginFunc: Failed validating:Error: Dependency Cycle Found: file:///mnt/vss/_work/1/azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/apimanagement.json -> file:///mnt/vss/_work/1/azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/definitions.json -> file:///mnt/vss/_work/1/azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2023-05-01-preview/definitions.json

We don't really need to care about cycles so just allow for them in our DepGraph object. 