### PR TITLE
Fix resourceNameRestriction to handle missing operation parameters

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/fix-resource-name-restriction_2023-10-11-20-05.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/fix-resource-name-restriction_2023-10-11-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix resourceNameRestriction to handle missing operation parameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2512,7 +2512,7 @@ const resourceNameRestriction = (paths, _opts, ctx) => {
         let parameters = [];
         const method = Object.keys(pathItem).find((k) => k !== "parameters");
         if (method) {
-            const operationParameters = pathItem[method].parameters;
+            const operationParameters = pathItem[method].parameters || [];
             parameters = parameters.concat(operationParameters);
         }
         if (pathItem.parameters) {

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/functions/resource-name-restriction.ts
+++ b/packages/rulesets/src/spectral/functions/resource-name-restriction.ts
@@ -12,7 +12,7 @@ export const resourceNameRestriction = (paths: any, _opts: any, ctx: any) => {
     let parameters: any[] = []
     const method = Object.keys(pathItem).find((k) => k !== "parameters")
     if (method) {
-      const operationParameters = pathItem[method].parameters
+      const operationParameters = pathItem[method].parameters || []
       parameters = parameters.concat(operationParameters)
     }
     if (pathItem.parameters) {

--- a/packages/rulesets/src/spectral/test/resource-names-restriction.test.ts
+++ b/packages/rulesets/src/spectral/test/resource-names-restriction.test.ts
@@ -87,6 +87,21 @@ test("ResourceNameRestriction should find no errors", () => {
           responses: {},
         },
       },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/My.NS/bar/{barName}": {
+        parameters: [
+          {
+            name: "fooName",
+            in: "path",
+            required: true,
+            type: "string",
+            pattern: "[a-zA-Z_0-9]+",
+            "x-ms-parameter-location": "method",
+          },
+        ],
+        get: {
+          responses: {},
+        },
+      },
     },
   }
   return linter.run(oasDoc).then((results) => {


### PR DESCRIPTION
This PR makes a little fix to the resourceNameRestriction function to correctly handle an operation that does not define any parameters.

This problem was exposed by [PR 25997](https://github.com/Azure/azure-rest-api-specs/pull/25977).

Test included.