### PR TITLE
Fixes the issue with PatchPropertiesCorrespondToPutProperties

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/fps-patchPropertiesCorrespondToPutProperties_2023-11-14-21-17.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/fps-patchPropertiesCorrespondToPutProperties_2023-11-14-21-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix an issue where PatchPropertiesCorrespondToPutProperties rule checks if the path has both PUT and PATCH calls.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2058,8 +2058,8 @@ const patchPropertiesCorrespondToPutProperties = (pathItem, _opts, ctx) => {
     const errors = [];
     const patchBodyProperties = (_b = (_a = pathItem[PATCH]) === null || _a === void 0 ? void 0 : _a.parameters) === null || _b === void 0 ? void 0 : _b.filter(PARAM_IN_BODY).map((param) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []));
     const putBodyProperties = (_d = (_c = pathItem[PUT]) === null || _c === void 0 ? void 0 : _c.parameters) === null || _d === void 0 ? void 0 : _d.filter(PARAM_IN_BODY).map((param) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []));
-    const patchBodyPropertiesEmpty = (patchBodyProperties === null || patchBodyProperties === void 0 ? void 0 : patchBodyProperties.length) < 1;
-    const putBodyPropertiesEmpty = (putBodyProperties === null || putBodyProperties === void 0 ? void 0 : putBodyProperties.length) < 1;
+    const patchBodyPropertiesEmpty = patchBodyProperties.length < 1;
+    const putBodyPropertiesEmpty = putBodyProperties.length < 1;
     if (patchBodyPropertiesEmpty) {
         return [
             {
@@ -2077,7 +2077,7 @@ const patchPropertiesCorrespondToPutProperties = (pathItem, _opts, ctx) => {
         ];
     }
     const patchBodyPropertiesNotInPutBody = _.differenceWith(patchBodyProperties[0], putBodyProperties[0], _.isEqual);
-    if ((patchBodyPropertiesNotInPutBody === null || patchBodyPropertiesNotInPutBody === void 0 ? void 0 : patchBodyPropertiesNotInPutBody.length) > 0) {
+    if (patchBodyPropertiesNotInPutBody.length > 0) {
         patchBodyPropertiesNotInPutBody.forEach((missingProperty) => errors.push({
             message: `${Object.keys(missingProperty)[0]} property in patch body is not present in the corresponding put body. ` + ERROR_MESSAGE$1,
             path: path,

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2051,15 +2051,15 @@ const PUT = "put";
 const PARAMETERS = "parameters";
 const patchPropertiesCorrespondToPutProperties = (pathItem, _opts, ctx) => {
     var _a, _b, _c, _d;
-    if (pathItem === null || typeof pathItem !== "object") {
+    if (pathItem === null || typeof pathItem !== "object" || pathItem[PATCH] === undefined || pathItem[PUT] === undefined) {
         return [];
     }
     const path = ctx.path.concat([PATCH, PARAMETERS]);
     const errors = [];
     const patchBodyProperties = (_b = (_a = pathItem[PATCH]) === null || _a === void 0 ? void 0 : _a.parameters) === null || _b === void 0 ? void 0 : _b.filter(PARAM_IN_BODY).map((param) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []));
     const putBodyProperties = (_d = (_c = pathItem[PUT]) === null || _c === void 0 ? void 0 : _c.parameters) === null || _d === void 0 ? void 0 : _d.filter(PARAM_IN_BODY).map((param) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []));
-    const patchBodyPropertiesEmpty = patchBodyProperties.length < 1;
-    const putBodyPropertiesEmpty = putBodyProperties.length < 1;
+    const patchBodyPropertiesEmpty = (patchBodyProperties === null || patchBodyProperties === void 0 ? void 0 : patchBodyProperties.length) < 1;
+    const putBodyPropertiesEmpty = (putBodyProperties === null || putBodyProperties === void 0 ? void 0 : putBodyProperties.length) < 1;
     if (patchBodyPropertiesEmpty) {
         return [
             {
@@ -2077,7 +2077,7 @@ const patchPropertiesCorrespondToPutProperties = (pathItem, _opts, ctx) => {
         ];
     }
     const patchBodyPropertiesNotInPutBody = _.differenceWith(patchBodyProperties[0], putBodyProperties[0], _.isEqual);
-    if (patchBodyPropertiesNotInPutBody.length > 0) {
+    if ((patchBodyPropertiesNotInPutBody === null || patchBodyPropertiesNotInPutBody === void 0 ? void 0 : patchBodyPropertiesNotInPutBody.length) > 0) {
         patchBodyPropertiesNotInPutBody.forEach((missingProperty) => errors.push({
             message: `${Object.keys(missingProperty)[0]} property in patch body is not present in the corresponding put body. ` + ERROR_MESSAGE$1,
             path: path,

--- a/packages/rulesets/src/spectral/functions/patch-properties-correspond-to-put-properties.ts
+++ b/packages/rulesets/src/spectral/functions/patch-properties-correspond-to-put-properties.ts
@@ -30,8 +30,8 @@ export const patchPropertiesCorrespondToPutProperties = (pathItem: any, _opts: a
     ?.filter(PARAM_IN_BODY)
     .map((param: any) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []))
 
-  const patchBodyPropertiesEmpty: boolean = patchBodyProperties?.length < 1
-  const putBodyPropertiesEmpty: boolean = putBodyProperties?.length < 1
+  const patchBodyPropertiesEmpty: boolean = patchBodyProperties.length < 1
+  const putBodyPropertiesEmpty: boolean = putBodyProperties.length < 1
 
   //patch without at least one body properties => error
   if (patchBodyPropertiesEmpty) {
@@ -57,7 +57,7 @@ export const patchPropertiesCorrespondToPutProperties = (pathItem: any, _opts: a
   //considering only the first element of patchBodyProperties & putBodyProperties is because there will only be one body param
   const patchBodyPropertiesNotInPutBody = _.differenceWith(patchBodyProperties[0], putBodyProperties[0], _.isEqual)
   // there is at least one property present in the patch body that is not present in the the put body => error
-  if (patchBodyPropertiesNotInPutBody?.length > 0) {
+  if (patchBodyPropertiesNotInPutBody.length > 0) {
     patchBodyPropertiesNotInPutBody.forEach((missingProperty) =>
       errors.push({
         message: `${Object.keys(missingProperty)[0]} property in patch body is not present in the corresponding put body. ` + ERROR_MESSAGE,

--- a/packages/rulesets/src/spectral/functions/patch-properties-correspond-to-put-properties.ts
+++ b/packages/rulesets/src/spectral/functions/patch-properties-correspond-to-put-properties.ts
@@ -13,7 +13,7 @@ const PUT = "put"
 const PARAMETERS = "parameters"
 
 export const patchPropertiesCorrespondToPutProperties = (pathItem: any, _opts: any, ctx: any) => {
-  if (pathItem === null || typeof pathItem !== "object") {
+  if (pathItem === null || typeof pathItem !== "object" || pathItem[PATCH] === undefined || pathItem[PUT] === undefined) {
     return []
   }
 
@@ -23,11 +23,15 @@ export const patchPropertiesCorrespondToPutProperties = (pathItem: any, _opts: a
   // array of all the patch body param properties
   // let patchBodyPropertiesList: any = []
   // let putBodyPropertiesList: any = []
-  const patchBodyProperties: any[] = pathItem[PATCH]?.parameters?.filter(PARAM_IN_BODY).map((param: any) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema,[]))
-  const putBodyProperties: any[] = pathItem[PUT]?.parameters?.filter(PARAM_IN_BODY).map((param: any) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema,[]))
+  const patchBodyProperties: any[] = pathItem[PATCH]?.parameters
+    ?.filter(PARAM_IN_BODY)
+    .map((param: any) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []))
+  const putBodyProperties: any[] = pathItem[PUT]?.parameters
+    ?.filter(PARAM_IN_BODY)
+    .map((param: any) => getAllPropertiesIncludingDeeplyNestedProperties(param.schema, []))
 
-  const patchBodyPropertiesEmpty: boolean = patchBodyProperties.length < 1
-  const putBodyPropertiesEmpty: boolean = putBodyProperties.length < 1
+  const patchBodyPropertiesEmpty: boolean = patchBodyProperties?.length < 1
+  const putBodyPropertiesEmpty: boolean = putBodyProperties?.length < 1
 
   //patch without at least one body properties => error
   if (patchBodyPropertiesEmpty) {
@@ -53,7 +57,7 @@ export const patchPropertiesCorrespondToPutProperties = (pathItem: any, _opts: a
   //considering only the first element of patchBodyProperties & putBodyProperties is because there will only be one body param
   const patchBodyPropertiesNotInPutBody = _.differenceWith(patchBodyProperties[0], putBodyProperties[0], _.isEqual)
   // there is at least one property present in the patch body that is not present in the the put body => error
-  if (patchBodyPropertiesNotInPutBody.length > 0) {
+  if (patchBodyPropertiesNotInPutBody?.length > 0) {
     patchBodyPropertiesNotInPutBody.forEach((missingProperty) =>
       errors.push({
         message: `${Object.keys(missingProperty)[0]} property in patch body is not present in the corresponding put body. ` + ERROR_MESSAGE,

--- a/packages/rulesets/src/spectral/test/patch-properties-correspond-to-put-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-properties-correspond-to-put-properties.test.ts
@@ -953,3 +953,165 @@ test("PatchPropertiesCorrespondToPutProperties should find no errors when patch 
     expect(results.length).toBe(0)
   })
 })
+
+test("PatchPropertiesCorrespondToPutProperties should not find error when patch doesnt exist", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}":
+        {
+          put: {
+            tags: ["NetworkWatchers"],
+            operationId: "NetworkWatchers_CreateOrUpdate",
+            description: "Creates or updates a network watcher in the specified resource group.",
+            parameters: [
+              {
+                name: "parameters",
+                in: "body",
+                required: true,
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+                description: "Parameters that define the network watcher resource.",
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Update successful. The operation returns the resulting network watcher resource.",
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+              },
+              "201": {
+                description: "Create successful. The operation returns the resulting network watcher resource.",
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+              },
+              default: {
+                description: "Error response describing why the operation failed.",
+                schema: {
+                  $ref: "#/definitions/ErrorResponse",
+                },
+              },
+            },
+          },
+          patch: {
+            tags: ["NetworkWatchers"],
+            operationId: "NetworkWatchers_UpdateTags",
+            description: "Updates a network watcher tags.",
+            parameters: [
+              {
+                name: "parameters",
+                in: "body",
+                required: true,
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+                description: "Parameters supplied to update network watcher tags.",
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Update successful. The operation returns the resulting network watcher resource.",
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+              },
+              default: {
+                description: "Error response describing why the operation failed.",
+                schema: {
+                  $ref: "#/definitions/ErrorResponse",
+                },
+              },
+            },
+          },
+        },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}":
+        {
+          put: {
+            tags: ["PacketCaptures"],
+            operationId: "PacketCaptures_Create",
+            description: "Create and start a packet capture on the specified VM.",
+            parameters: [
+              {
+                name: "parameters",
+                in: "body",
+                required: true,
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+                description: "Parameters that define the create packet capture operation.",
+              },
+            ],
+            responses: {
+              "201": {
+                description: "Request successful. The operation returns the resulting packet capture session.",
+                schema: {
+                  $ref: "#/definitions/PacketCapture",
+                },
+              },
+              default: {
+                description: "Error response describing why the operation failed.",
+                schema: {
+                  $ref: "#/definitions/ErrorResponse",
+                },
+              },
+            },
+            "x-ms-long-running-operation": true,
+            "x-ms-long-running-operation-options": {
+              "final-state-via": "azure-async-operation",
+            },
+          },
+        },
+    },
+    definitions: {
+      ErrorResponse: {
+        description: "The error object.",
+        properties: {
+          error: {
+            title: "Error",
+            description: "The error details object.",
+          },
+        },
+      },
+      PacketCapture: {
+        properties: {
+          properties: {
+            "x-ms-client-flatten": true,
+            $ref: "#/definitions/PacketCaptureParameters",
+            description: "Properties of the packet capture.",
+          },
+        },
+        required: ["properties"],
+        description: "Parameters that define the create packet capture operation.",
+      },
+      PacketCaptureParameters: {
+        properties: {
+          scope: {
+            $ref: "#/definitions/PacketCaptureMachineScope",
+            description: "A list of AzureVMSS instances",
+          },
+        },
+        required: ["target", "storageLocation"],
+        description: "Parameters that define the create packet capture operation.",
+      },
+      PacketCaptureMachineScope: {
+        type: "object",
+        properties: {
+          include: {
+            type: "array",
+            description: "List of AzureVMSS instances to run packet capture on.",
+            items: {
+              type: "string",
+            },
+          },
+        },
+        description: "A list of AzureVMSS",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
The PatchPropertiesCorrespondToPutProperties rule should verify whether a given path contains both PUT and PATCH calls. If either of this call is missing, the lint check should raise a fatal error. The comparison of properties between these two calls becomes problematic when one of them (in this case, PATCH) is undefined. Consequently, applying a filter to retrieve properties from an undefined variable is not feasible.

PR which failed with Fatal Errors: https://github.com/Azure/azure-rest-api-specs/pull/26281/checks?check_run_id=17848084756