### PR TITLE
Fix fatal error caused by undefined parameters in ParametersInPointGet

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_fatal_errors_in_ParametersInPointGet_2023-11-15-21-21.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_fatal_errors_in_ParametersInPointGet_2023-11-15-21-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix fatal error caused by undefined parameters in ParametersInPointGet rule",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -864,7 +864,6 @@ Please refer to [path-contains-subscription-id.md](./path-contains-subscription-
 ### PathForNestedResource
 
 Path for CRUD methods on a nested resource type MUST follow valid resource naming, like '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MyNameSpace/MyResourceType/{Name}/NestedResourceType/{nestedResourceName}'.
-
 There is one exception where extension resources with fully qualified path of the below format can exist
 "/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}/{resourceProviderScope}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/groupQuotaRequests/{requestId}"
 In such cases the author would need to suppress the error being flagged using https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md#suppress-warnings

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1982,8 +1982,8 @@ const ParametersInPointGet = (pathItem, _opts, ctx) => {
         const hierarchy = getResourcesPathHierarchyBasedOnResourceType(uri);
         if (hierarchy.length >= 1 && pathItem[uri][GET]) {
             const params = pathItem[uri][GET]["parameters"];
-            const queryParams = params.filter((param) => param.in === "query" && param.name !== "api-version");
-            queryParams.map((param) => {
+            const queryParams = params === null || params === void 0 ? void 0 : params.filter((param) => param.in === "query" && param.name !== "api-version");
+            queryParams === null || queryParams === void 0 ? void 0 : queryParams.map((param) => {
                 errors.push({
                     message: `Query parameter ${param.name} should be removed. Point Get's MUST not have query parameters other than api version.`,
                     path: [path, uri, GET, "parameters"],

--- a/packages/rulesets/src/spectral/functions/parameters-in-point-get.ts
+++ b/packages/rulesets/src/spectral/functions/parameters-in-point-get.ts
@@ -17,8 +17,8 @@ export const ParametersInPointGet = (pathItem: any, _opts: any, ctx: any) => {
     const hierarchy = getResourcesPathHierarchyBasedOnResourceType(uri)
     if (hierarchy.length >= 1 && pathItem[uri][GET]) {
       const params = pathItem[uri][GET]["parameters"]
-      const queryParams = params.filter((param: { in: string; name: string }) => param.in === "query" && param.name !== "api-version")
-      queryParams.map((param: { name: any }) => {
+      const queryParams = params?.filter((param: { in: string; name: string }) => param.in === "query" && param.name !== "api-version")
+      queryParams?.map((param: { name: any }) => {
         errors.push({
           message: `Query parameter ${param.name} should be removed. Point Get's MUST not have query parameters other than api version.`,
           path: [path, uri, GET, "parameters"],

--- a/packages/rulesets/src/spectral/test/parameters-in-point-get.test.ts
+++ b/packages/rulesets/src/spectral/test/parameters-in-point-get.test.ts
@@ -316,7 +316,7 @@ test("ParametersInPointGet should find no errors for a list operation", () => {
               $ref: "src/spectral/test/resources/types.json#/parameters/ResourceGroupNameParameter",
             },
             {
-              $ref: "#/parameters/LoadTestNameParameter",
+              $ref: "#/parameters/QuotaBucketNameParameter",
             },
           ],
           responses: {
@@ -334,7 +334,7 @@ test("ParametersInPointGet should find no errors for a list operation", () => {
               $ref: "src/spectral/test/resources/types.json#/parameters/ResourceGroupNameParameter",
             },
             {
-              $ref: "#/parameters/LoadTestNameParameter",
+              $ref: "#/parameters/QuotaBucketNameParameter",
             },
           ],
           responses: {
@@ -381,7 +381,7 @@ test("ParametersInPointGet should find no errors for a non get operation", () =>
               $ref: "src/spectral/test/resources/types.json#/parameters/ResourceGroupNameParameter",
             },
             {
-              $ref: "#/parameters/LoadTestNameParameter",
+              $ref: "#/parameters/QuotaBucketNameParameter",
             },
           ],
           responses: {
@@ -464,5 +464,44 @@ test("ParametersInPointGet should find errors for x-ms-paths", () => {
     expect(results[0].message).toContain(
       "Query parameter quotaBucketName should be removed. Point Get's MUST not have query parameters other than api version."
     )
+  })
+})
+
+test("ParametersInPointGet should find no errors if parameters is not defined", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}": {
+        get: {
+          operationId: "foo_post",
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+      },
+    },
+    parameters: {
+      LoadTestNameParameter: {
+        in: "path",
+        name: "loadTestName",
+        description: "Load Test name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
   })
 })


### PR DESCRIPTION
Undefined params cause the rule to fail with fatal error-https://github.com/Azure/azure-rest-api-specs/pull/26218/checks?check_run_id=18133490258
This PR fixes the issue