### PR TITLE
Change the rule AllTrackedResourcesMustHaveDelete to flag an error even when a Put operation is not specified

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fix_Delete-V1-03_2023-12-08-04-39.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fix_Delete-V1-03_2023-12-08-04-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Modify the rule AllTrackedResourcesMustHaveDelete to flag an error even when a Put operation is not specified for Tracked resources",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/all-proxy-resources-should-have-delete.md
+++ b/docs/all-proxy-resources-should-have-delete.md
@@ -12,22 +12,299 @@ ARM OpenAPI(swagger) specs
 
 - RPC-Delete-V1-05
 
-## Output Message
-
-The resource {resourceName} does not have a corresponding delete operation.
-
 ## Description
 
-All proxy resources SHOULD support delete.
+All proxy resources that have a put operation defined should also support a delete operation. This makes the APIs intuitive for customers as they would expect every resource that they have the ability to create to also be deletable. There are rare sceanrios where a customer is allowed to create and replace a resource but never be able to delete them. In such cases it is ok to not implement a delete but such cases are very rare and should be avoided. 
 
-## CreatedAt
+## How to fix
 
-July 07, 2022
+Add the delete operation for the proxy resource.
 
-## LastModifiedAt
+## Bad examples
 
-Feb 10, 2023
+A proxy resource having a put operation but no delete operation
+```json
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_CreateOrUpdate",
+        "description": "Put HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            },
+          "201": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+```
 
-## How to fix the violation
 
-Adding the put operation for tracked resource.
+## Good example
+
+## Good example 1 
+A proxy resource having both put and delete operations
+
+```json
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_CreateOrUpdate",
+        "description": "Put HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            },
+          "201": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    },
+    "delete": {
+      "tags": [
+        "Nodes"
+      ],
+      "operationId": "Node_Delete",
+      "description": "Delete HDInsightnode",
+      "x-ms-examples": null,
+      "parameters": [
+        {
+          "$ref": "#/parameters/SubscriptionIdParameter"
+        },
+        {
+          "$ref": "#/parameters/ResourceGroupNameParameter"
+        },
+        {
+          "$ref": "#/parameters/NodeNameParameter"
+        },
+        {
+          "$ref": "#/parameters/ApiVersionParameter"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Resource deleted successfully."
+        },
+        "204": {
+          "description": "Resource is already deleted.",
+        },
+        "default": {
+          "description": "Error response describing why the operation failed.",
+          "schema": {
+            "$ref": "#/definitions/ErrorResponse"
+          }
+        }
+      },
+      "produces": [
+        "application/json"
+      ],
+      "consumes": [
+        "application/json"
+      ]
+    }
+  }    
+```
+## Good example 2 
+A read only proxy resource having no put or delete operations
+
+```json
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+```

--- a/docs/all-proxy-resources-should-have-delete.md
+++ b/docs/all-proxy-resources-should-have-delete.md
@@ -18,7 +18,7 @@ All proxy resources that have a put operation defined should also support a dele
 
 ## How to fix
 
-Add the delete operation for the proxy resource.
+Consider adding the delete operation for the proxy resource that has a PUT.
 
 ## Bad examples
 
@@ -50,7 +50,7 @@ A proxy resource having a put operation but no delete operation
           "200": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             }
           },
           "default": {
@@ -92,12 +92,12 @@ A proxy resource having a put operation but no delete operation
           "200": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             },
           "201": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             }
           },
           "default": {
@@ -150,7 +150,7 @@ A proxy resource having both put and delete operations
           "200": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             }
           },
           "default": {
@@ -192,12 +192,12 @@ A proxy resource having both put and delete operations
           "200": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             },
           "201": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             }
           },
           "default": {
@@ -289,7 +289,7 @@ A read only proxy resource having no put or delete operations
           "200": {
             "description": "OK response definition.",
             "schema": {
-              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a proxy resource
+              "$ref": "./proxyResourceCommon.json#/definitions/Node" // Node is a proxy resource
             }
           },
           "default": {

--- a/docs/all-tracked-resources-must-have-delete.md
+++ b/docs/all-tracked-resources-must-have-delete.md
@@ -12,22 +12,294 @@ ARM OpenAPI(swagger) specs
 
 - RPC-Delete-V1-03
 
-## Output Message
-
-The resource {resourceName} does not have a corresponding delete operation.
-
 ## Description
 
 All tracked resources MUST support delete.
 
-## CreatedAt
+## How to fix
 
-July 07, 2022
+Add the delete operation for the tracked resource.
 
-## LastModifiedAt
+## Bad examples
 
-Feb 10, 2023
+## Bad example 1
+```json
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+```
+## Bad example 2
+```json
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_CreateOrUpdate",
+        "description": "Put HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            },
+          "201": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+```
 
-## How to fix the violation
 
-Adding the put operation for tracked resource.
+## Good example
+
+```json
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_CreateOrUpdate",
+        "description": "Put HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            },
+          "201": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Node" // Node is a tracked resource
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    },
+    "delete": {
+      "tags": [
+        "Nodes"
+      ],
+      "operationId": "Node_Delete",
+      "description": "Delete HDInsightnode",
+      "x-ms-examples": null,
+      "parameters": [
+        {
+          "$ref": "#/parameters/SubscriptionIdParameter"
+        },
+        {
+          "$ref": "#/parameters/ResourceGroupNameParameter"
+        },
+        {
+          "$ref": "#/parameters/NodeNameParameter"
+        },
+        {
+          "$ref": "#/parameters/ApiVersionParameter"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Resource deleted successfully."
+        },
+        "204": {
+          "description": "Resource is already deleted.",
+        },
+        "default": {
+          "description": "Error response describing why the operation failed.",
+          "schema": {
+            "$ref": "#/definitions/ErrorResponse"
+          }
+        }
+      },
+      "produces": [
+        "application/json"
+      ],
+      "consumes": [
+        "application/json"
+      ]
+    }
+  }    
+```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,7 +18,7 @@ Please refer to [additional-properties-object.md](./additional-properties-object
 
 ### AllProxyResourcesShouldHaveDelete
 
-All proxy resources SHOULD support delete.
+All proxy resources that have a put operation defined should also support a delete operation. This makes the APIs intuitive for customers as they would expect every resource that they have the ability to create to also be deletable. There are rare sceanrios where a customer is allowed to create and replace a resource but never be able to delete them. In such cases it is ok to not implement a delete but such cases are very rare and should be avoided. 
 
 Please refer to [all-proxy-resources-should-have-delete.md](./all-proxy-resources-should-have-delete.md) for details.
 

--- a/packages/rulesets/src/native/functions/arm-resource-validation.ts
+++ b/packages/rulesets/src/native/functions/arm-resource-validation.ts
@@ -37,7 +37,7 @@ export function* allResourcesHaveDelete(openapiSection: any, options: { isTracke
   for (const re of allResources) {
     const apiPath = re.operations.find((op) => op.apiPath)?.apiPath
     if (apiPath) {
-      if (armHelper.findOperation(apiPath, "put") && !armHelper.findOperation(apiPath, "delete")) {
+      if ((options.isTrackedResource || armHelper.findOperation(apiPath, "put")) && !armHelper.findOperation(apiPath, "delete")) {
         yield {
           location: ["definitions", re.modelName],
           message: `The resource ${re.modelName} does not have a corresponding delete operation.`,

--- a/packages/rulesets/src/native/tests/individual-azure-tests.ts
+++ b/packages/rulesets/src/native/tests/individual-azure-tests.ts
@@ -283,6 +283,14 @@ describe("IndividualAzureTests", () => {
     getErrorMessages(messages)
   })
 
+  test("Tracked resources with delete operations should not flag an error", async () => {
+    const fileNames = ["armResource/trackedResourceWithDelete.json", "armResource/trackedResourceCommon.json"]
+    const ruleName = "AllTrackedResourcesMustHaveDelete"
+    const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
+    assertValidationRuleCount(messages, ruleName, 0)
+    getErrorMessages(messages)
+  })
+
   test("no delete in for proxy resource", async () => {
     const fileNames = ["armResource/proxyResourceNoDelete.json", "armResource/proxyResourceCommon.json"]
     const ruleName = "AllProxyResourcesShouldHaveDelete"
@@ -293,6 +301,13 @@ describe("IndividualAzureTests", () => {
 
   test("no delete in for proxy resource with no put", async () => {
     const fileNames = ["armResource/proxyResourceNoDeleteNoPut.json", "armResource/proxyResourceCommon.json"]
+    const ruleName = "AllProxyResourcesShouldHaveDelete"
+    const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
+    assertValidationRuleCount(messages, ruleName, 0)
+  })
+
+  test("Proxy resources with delete operations should not flag an error", async () => {
+    const fileNames = ["armResource/proxyResourceWithDelete.json", "armResource/proxyResourceCommon.json"]
     const ruleName = "AllProxyResourcesShouldHaveDelete"
     const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
     assertValidationRuleCount(messages, ruleName, 0)

--- a/packages/rulesets/src/native/tests/individual-azure-tests.ts
+++ b/packages/rulesets/src/native/tests/individual-azure-tests.ts
@@ -181,7 +181,6 @@ describe("IndividualAzureTests", () => {
     assertValidationRuleCount(messages, XmsPageableMustHaveCorrespondingResponse, 0)
   })
 
-
   test("Preview version over a year", async () => {
     const fileName = "PreviewVersionOverOneYear.json"
     const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileName, OpenApiTypes.arm, PreviewVersionOverOneYear)
@@ -268,7 +267,7 @@ describe("IndividualAzureTests", () => {
     assertValidationRuleCount(messages, ruleName, 1)
   })
 
-  test("no delete in for tracked resource", async () => {
+  test("no delete in for tracked resource with put", async () => {
     const fileNames = ["armResource/trackedResourceNoDelete.json", "armResource/trackedResourceCommon.json"]
     const ruleName = "AllTrackedResourcesMustHaveDelete"
     const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
@@ -276,12 +275,27 @@ describe("IndividualAzureTests", () => {
     getErrorMessages(messages)
   })
 
-  test("no delete in for proxy resource", async () => {
-    const fileNames = ["armResource/trackedResourceNoDelete.json", "armResource/trackedResourceCommon.json"]
-    const ruleName = "AllProxyResourcesShouldHaveDelete"
+  test("no delete in for tracked resource with no put", async () => {
+    const fileNames = ["armResource/trackedResourceNoDeleteNoPut.json", "armResource/trackedResourceCommon.json"]
+    const ruleName = "AllTrackedResourcesMustHaveDelete"
     const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
     assertValidationRuleCount(messages, ruleName, 1)
+    getErrorMessages(messages)
+  })
+
+  test("no delete in for proxy resource", async () => {
+    const fileNames = ["armResource/proxyResourceNoDelete.json", "armResource/proxyResourceCommon.json"]
+    const ruleName = "AllProxyResourcesShouldHaveDelete"
+    const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
+    assertValidationRuleCount(messages, ruleName, 2)
     getWarningMessages(messages)
+  })
+
+  test("no delete in for proxy resource with no put", async () => {
+    const fileNames = ["armResource/proxyResourceNoDeleteNoPut.json", "armResource/proxyResourceCommon.json"]
+    const ruleName = "AllProxyResourcesShouldHaveDelete"
+    const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
+    assertValidationRuleCount(messages, ruleName, 0)
   })
 
   test("tracked resource beyonds third level", async () => {

--- a/packages/rulesets/src/native/tests/resources/armResource/proxyResourceCommon.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/proxyResourceCommon.json
@@ -1,0 +1,124 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-06-01-preview",
+    "title": "HDInsightManagementClient",
+    "description": "HDInsight Management Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {},
+  "definitions": {
+    "Resource": {
+      "description": "The core properties of ARM resources",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResource": {
+      "description": "The resource model definition for a ARM tracked top level resource",
+      "properties": {
+        "location": {
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "description": "The Azure Region where the resource lives"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create",
+            "update"
+          ],
+          "description": "Resource tags."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "Cluster": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag for the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/ClusterGetProperties",
+          "description": "The properties of the cluster."
+        }
+      },
+      "description": "The HDInsight cluster."
+    },
+    "ClusterGetProperties": {
+      "description": "The properties of cluster.",
+      "properties": {
+        "clusterVersion": {
+          "type": "string",
+          "description": "The version of the cluster."
+        },
+        "osType": {
+          "type": "string",
+          "description": "The type of operating system.",
+          "enum": [
+            "Windows",
+            "Linux"
+          ],
+          "x-ms-enum": {
+            "name": "OSType",
+            "modelAsString": false
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/packages/rulesets/src/native/tests/resources/armResource/proxyResourceNoDelete.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/proxyResourceNoDelete.json
@@ -1,0 +1,182 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-06-01-preview",
+    "title": "HDInsightManagementClient",
+    "description": "HDInsight Management Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}": {
+      "put": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/Cluster"
+            }
+          },
+          "201": {
+            "description": "resource created response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/ClusterGetProperties"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/ClusterGetProperties"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ErrorResponse": {
+      "description": "Describes the format of Error response.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code",
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./proxyResourceCommon.json#/definitions/Cluster"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "ClusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the cluster.",
+      "x-ms-parameter-location": "method"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The HDInsight client API Version."
+    }
+  }
+}

--- a/packages/rulesets/src/native/tests/resources/armResource/proxyResourceNoDeleteNoPut.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/proxyResourceNoDeleteNoPut.json
@@ -1,0 +1,134 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-06-01-preview",
+    "title": "HDInsightManagementClient",
+    "description": "HDInsight Management Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ErrorResponse": {
+      "description": "Describes the format of Error response.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code",
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./proxyResourceCommon.json#/definitions/Cluster"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "ClusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the cluster.",
+      "x-ms-parameter-location": "method"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The HDInsight client API Version."
+    }
+  }
+}

--- a/packages/rulesets/src/native/tests/resources/armResource/proxyResourceWithDelete.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/proxyResourceWithDelete.json
@@ -1,0 +1,224 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-06-01-preview",
+    "title": "HDInsightManagementClient",
+    "description": "HDInsight Management Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}": {
+      "put": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/Cluster"
+            }
+          },
+          "201": {
+            "description": "resource created response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/ClusterGetProperties"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./proxyResourceCommon.json#/definitions/ClusterGetProperties"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource already deleted."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ErrorResponse": {
+      "description": "Describes the format of Error response.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code",
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./proxyResourceCommon.json#/definitions/Cluster"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "ClusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the cluster.",
+      "x-ms-parameter-location": "method"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The HDInsight client API Version."
+    }
+  }
+}

--- a/packages/rulesets/src/native/tests/resources/armResource/trackedResourceNoDeleteNoPut.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/trackedResourceNoDeleteNoPut.json
@@ -1,0 +1,134 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-06-01-preview",
+    "title": "HDInsightManagementClient",
+    "description": "HDInsight Management Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/nodes/{nodeName}": {
+      "get": {
+        "tags": [
+          "Nodes"
+        ],
+        "operationId": "Node_Get",
+        "description": "Get HDInsightnode",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/NodeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ErrorResponse": {
+      "description": "Describes the format of Error response.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code",
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./trackedResourceCommon.json#/definitions/Cluster"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "ClusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the cluster.",
+      "x-ms-parameter-location": "method"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The HDInsight client API Version."
+    }
+  }
+}

--- a/packages/rulesets/src/native/tests/resources/armResource/trackedResourceWithDelete.json
+++ b/packages/rulesets/src/native/tests/resources/armResource/trackedResourceWithDelete.json
@@ -1,0 +1,224 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-06-01-preview",
+    "title": "HDInsightManagementClient",
+    "description": "HDInsight Management Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}": {
+      "put": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/Cluster"
+            }
+          },
+          "201": {
+            "description": "resource created response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/ClusterGetProperties"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response definition.",
+            "schema": {
+              "$ref": "./trackedResourceCommon.json#/definitions/ClusterGetProperties"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Clusters"
+        ],
+        "operationId": "Clusters_Update",
+        "description": "Patch HDInsight cluster with the specified parameters.",
+        "x-ms-examples": null,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ClusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource already deleted."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ErrorResponse": {
+      "description": "Describes the format of Error response.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Error code",
+          "type": "string"
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./trackedResourceCommon.json#/definitions/Cluster"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "ClusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the cluster.",
+      "x-ms-parameter-location": "method"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The HDInsight client API Version."
+    }
+  }
+}


### PR DESCRIPTION
The rule AllTrackedResourcesMustHaveDelete flags an error when a Delete operation is not specified for a Tracked resource only when a Put is specified. This rule must flag an error irrespective of whether a Put is specified or not for a tracked resource. This change ensures the same.
 