### PR TITLE
Fix client flatten documentation and add tests

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fixClientFlattenDocumentation_2023-12-09-02-48.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/rkmanda-fixClientFlattenDocumentation_2023-12-09-02-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix documentation and add tests for the AvoidNestedProperties rule",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/avoid-nested-properties.md
+++ b/docs/avoid-nested-properties.md
@@ -20,6 +20,101 @@ Nested properties can result into bad user experience especially when creating r
 
 Overly nested properties (especially required ones) can result into a non optimal user experience.
 
-## How to fix the violation
+## How to fix
 
 Either eliminate nesting or use the `x-ms-client-flatten` property for a better user experience. More details about the extension can be found [here](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md#x-ms-client-flatten).
+
+## Bad examples
+
+## Bad example 1
+Deeply nested properties exist and the x-ms-client-flatten extension is not specified
+
+```json
+    definitions: {
+      externalDocs: {
+        type: "object",
+        properties: {
+          tags: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+            description: "Resource tags.",
+          },
+          properties: {
+            type: "object",
+            properties: {
+              timeOfDayUTC: {
+                type: "string",
+                pattern: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+                description: "The time of day (in UTC) to start the maintenance window.",
+              },
+            },
+          },
+        },
+      },
+    },
+```
+
+## Bad example 2
+Deeply nested properties exist and the x-ms-client-flatten extension is specified in the schema object and not against the complex type
+
+```json
+    definitions: {
+      externalDocs: {
+        type: "object",
+        properties: {
+          tags: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+            description: "Resource tags.",
+          },
+          properties: {
+            type: "object",
+            // x-ms-client-flatten should have been specified here
+            properties: {
+              "x-ms-client-flatten": true,
+              timeOfDayUTC: {
+                type: "string",
+                pattern: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+                description: "The time of day (in UTC) to start the maintenance window.",
+              },
+            },
+          },
+        },
+      },
+    },
+```
+## Good examples
+
+Deeply nested properties exist and the x-ms-client-flatten extension is specified against the complex type
+
+```json
+    definitions: {
+      externalDocs: {
+        type: "object",
+        properties: {
+          tags: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+            description: "Resource tags.",
+          },
+          properties: {
+            type: "object",
+            "x-ms-client-flatten": true,
+            properties: {
+              timeOfDayUTC: {
+                type: "string",
+                pattern: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+                description: "The time of day (in UTC) to start the maintenance window.",
+              },
+            },
+          },
+        },
+      },
+    },
+```

--- a/docs/avoid-nested-properties.md
+++ b/docs/avoid-nested-properties.md
@@ -8,21 +8,13 @@ SDK Warning
 
 ARM and Data plane OpenAPI(swagger) specs
 
-## Output Message
-
-Consider using x-ms-client-flatten to provide a better end user experience
-
 ## Description
 
-Nested properties can result into bad user experience especially when creating request objects. `x-ms-client-flatten` flattens the model properties so that the users can analyze and set the properties much more easily.
-
-## Why the rule is important
-
-Overly nested properties (especially required ones) can result into a non optimal user experience.
+Consider using x-ms-client-flatten to provide a better end user experience. Nested properties can result into bad user experience especially when creating request objects. `x-ms-client-flatten` flattens the model properties so that the users can analyze and set the properties much more easily. Overly nested properties (especially required ones) can result into a non optimal user experience.
 
 ## How to fix
 
-Either eliminate nesting or use the `x-ms-client-flatten` property for a better user experience. More details about the extension can be found [here](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md#x-ms-client-flatten).
+Use the `x-ms-client-flatten` property for a better user experience. More details about the extension can be found [here](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md#x-ms-client-flatten).
 
 ## Bad examples
 
@@ -88,6 +80,8 @@ Deeply nested properties exist and the x-ms-client-flatten extension is specifie
     },
 ```
 ## Good examples
+
+## Good example 1 
 
 Deeply nested properties exist and the x-ms-client-flatten extension is specified against the complex type
 

--- a/packages/rulesets/src/spectral/test/avoid-nested-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/avoid-nested-properties.test.ts
@@ -17,17 +17,25 @@ test("AvoidNestedProperties should find errors", () => {
     },
     definitions: {
       externalDocs: {
+        type: "object",
         properties: {
+          tags: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+            description: "Resource tags.",
+          },
           properties: {
+            type: "object",
             properties: {
-              $ref: "#/definitions/BackendProperties",
+              timeOfDayUTC: {
+                type: "string",
+                pattern: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+                description: "The time of day (in UTC) to start the maintenance window.",
+              },
             },
           },
-        },
-      },
-      BackendProperties: {
-        properties: {
-          $ref: "#/definitions/externalDocs",
         },
       },
     },
@@ -48,6 +56,7 @@ test("AvoidNestedProperties should find no errors", () => {
       externalDocs: {
         properties: {
           properties: {
+            type: "object",
             "x-ms-client-flatten": true,
             $ref: "#/definitions/BackendProperties",
           },
@@ -56,6 +65,82 @@ test("AvoidNestedProperties should find no errors", () => {
       BackendProperties: {
         properties: {
           $ref: "#/definitions/externalDocs",
+        },
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("AvoidNestedProperties should find errors when the extension is specified outside the complex type definition", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    info: {
+      description:
+        "Use these APIs to manage Azure Websites resources through the Azure Resource Manager. All task operations conform to the HTTP/1.1 protocol specification and each operation returns an x-ms-request-id header that can be used to obtain information about the request. You must make sure that requests made to these resources are secure. For more information, see https://msdn.microsoft.com/en-us/library/azure/dn790557.aspx.",
+    },
+    definitions: {
+      externalDocs: {
+        type: "object",
+        properties: {
+          tags: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+            description: "Resource tags.",
+          },
+          properties: {
+            type: "object",
+            properties: {
+              "x-ms-client-flatten": true,
+              timeOfDayUTC: {
+                type: "string",
+                pattern: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+                description: "The time of day (in UTC) to start the maintenance window.",
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(1)
+  })
+})
+
+test("AvoidNestedProperties should not find errors when the extension is specified for a complex type definition", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    info: {
+      description:
+        "Use these APIs to manage Azure Websites resources through the Azure Resource Manager. All task operations conform to the HTTP/1.1 protocol specification and each operation returns an x-ms-request-id header that can be used to obtain information about the request. You must make sure that requests made to these resources are secure. For more information, see https://msdn.microsoft.com/en-us/library/azure/dn790557.aspx.",
+    },
+    definitions: {
+      externalDocs: {
+        type: "object",
+        properties: {
+          tags: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+            description: "Resource tags.",
+          },
+          properties: {
+            type: "object",
+            "x-ms-client-flatten": true,
+            properties: {
+              timeOfDayUTC: {
+                type: "string",
+                pattern: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+                description: "The time of day (in UTC) to start the maintenance window.",
+              },
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
An issue was raised indicating that the linter rule was raising a false alarm in this PR

https://github.com/Azure/azure-rest-api-specs/pull/23563/checks?check_run_id=12809910224

On investigating this it was found that the linter rule was working correctly. The issue was that the type:object declaration was missing where it should have been present.

This change is to update the documentation to call out explicitly what the good and bad patterns are. This change also adds more tests