### PR TITLE
Fix null check for latestVersionOfCommonTypesMustBeUsed

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_null_check_latestVersionOfCommonTypesMustBeUsed_2023-12-12-18-23.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_null_check_latestVersionOfCommonTypesMustBeUsed_2023-12-12-18-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix null check for latestVersionOfCommonTypesMustBeUsed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1683,7 +1683,7 @@ const httpsSupportedScheme = (scheme, _opts, paths) => {
 
 const latestVersionOfCommonTypesMustBeUsed = (ref, _opts, ctx) => {
     const REF_COMMON_TYPES_REGEX = new RegExp("/common-types/resource-management/v\\d+/\\w+.json#", "gi");
-    if (ref !== null && !ref.match(REF_COMMON_TYPES_REGEX)) {
+    if (ref === null || !ref.match(REF_COMMON_TYPES_REGEX)) {
         return [];
     }
     const errors = [];

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/functions/latest-version-of-common-types-must-be-used.ts
+++ b/packages/rulesets/src/spectral/functions/latest-version-of-common-types-must-be-used.ts
@@ -3,7 +3,7 @@ import { LATEST_VERSION_BY_COMMON_TYPES_FILENAME, isLatestCommonTypesVersionForF
 export const latestVersionOfCommonTypesMustBeUsed = (ref: any, _opts: any, ctx: any) => {
   const REF_COMMON_TYPES_REGEX = new RegExp("/common-types/resource-management/v\\d+/\\w+.json#", "gi")
 
-  if (ref !== null && !ref.match(REF_COMMON_TYPES_REGEX)) {
+  if (ref === null || !ref.match(REF_COMMON_TYPES_REGEX)) {
     return []
   }
   const errors = []


### PR DESCRIPTION
Replicating https://github.com/Azure/azure-openapi-validator/pull/620 with version bump