### PR TITLE
Update doc for ProvisioningStateMustBeReadOnly

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-update_-ProvisioningStateMustBeReadOnly_doc_2023-12-15-06-39.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-update_-ProvisioningStateMustBeReadOnly_doc_2023-12-15-06-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator-rulesets",
-      "comment": "Add RPC code to ProvisioningStateMustBeReadOnly",
+      "comment": "Add RPC code to ProvisioningStateMustBeReadOnly and fix documentation",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-update_-ProvisioningStateMustBeReadOnly_doc_2023-12-15-06-39.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-update_-ProvisioningStateMustBeReadOnly_doc_2023-12-15-06-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Add RPC code to ProvisioningStateMustBeReadOnly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/provisioning-state-must-be-read-only.md
+++ b/docs/provisioning-state-must-be-read-only.md
@@ -8,6 +8,10 @@ ARM Error
 
 ARM OpenAPI(swagger) specs
 
+## Related ARM Guideline Code
+
+- RPC-Async-V1-16
+
 ## Description
 
 This is a rule introduced to validate if provisioningState property is set to readOnly.

--- a/docs/provisioning-state-must-be-read-only.md
+++ b/docs/provisioning-state-must-be-read-only.md
@@ -8,16 +8,164 @@ ARM Error
 
 ARM OpenAPI(swagger) specs
 
-## Output Message
-
-provisioningState property must be set to readOnly.
-
 ## Description
 
 This is a rule introduced to validate if provisioningState property is set to readOnly.
 
 ## How to fix the violation
 
-Set the `provisioningState` property `readOnly`.
-I.e., `"readOnly": true`
-should be added to "provisioningState" property.
+Set the `provisioningState` property `readOnly`, i.e, `"readOnly": true` should be added to "provisioningState" property.
+Make sure to add the `"readOnly": true` to the actual "provisioningState" definition and not to the envelope property(i.e, property that references the actual definition)
+
+
+## Bad example 1 
+
+provisioningState without readOnly 
+
+```json5
+ "put": {
+    "responses": {
+      "200": {
+        "description": "Success",
+        "schema": {
+          "$ref": "#/definitions/FooProps",
+        },
+      },
+    }
+ }
+"definitions": {
+    "FooProps": {
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the foo rule.",
+          "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+        },
+      },
+    },
+}
+```
+
+    
+## Bad example 2 
+
+provisioningState with readOnly defined in the envelope property and not in the actual definition
+
+```json5
+ "put": {
+    "responses": {
+      "200": {
+        "description": "Success",
+        "schema": {
+          "$ref": "#/definitions/FooRule",
+        },
+      },
+    }
+ }
+"definitions": {
+   "ProvisioningState": {
+      "type": "string",
+      "enum": ["Succeeded", "Failed", "Canceled"],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+      },
+    },
+    "FooRule": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FooProps",
+          "x-ms-client-flatten": true,
+        },
+      },
+    },
+    "FooProps": {
+      "properties": {
+        "provisioningState": {
+        "$ref": "#/definitions/ProvisioningState",
+        "readOnly": true,
+        "type": "string",
+        "description": "Provisioning state of the foo rule.",
+        "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+        },
+      },
+    }
+}
+```
+
+## Good example 1
+
+provisioningState with readOnly defined
+
+```json5
+ "put": {
+    "responses": {
+      "200": {
+        "description": "Success",
+        "schema": {
+          "$ref": "#/definitions/FooProps",
+        },
+      },
+    }
+ }
+"definitions": {
+    "FooProps": {
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Provisioning state of the foo rule.",
+          "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+        },
+      },
+    },
+}
+```
+
+## Good example 2 
+
+provisioningState with readOnly defined in the actual definition
+
+```json5
+ "put": {
+    "responses": {
+      "200": {
+        "description": "Success",
+        "schema": {
+          "$ref": "#/definitions/FooRule",
+        },
+      },
+    }
+ }
+"definitions": {
+   "ProvisioningState": {
+      "type": "string",
+      "readOnly": true,
+      "enum": ["Succeeded", "Failed", "Canceled"],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+      },
+    },
+    "FooRule": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FooProps",
+          "x-ms-client-flatten": true,
+        },
+      },
+    },
+    "FooProps": {
+      "properties": {
+        "provisioningState": {
+        "$ref": "#/definitions/ProvisioningState",
+        "type": "string",
+        "description": "Provisioning state of the foo rule.",
+        "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+        },
+      },
+    }
+}
+```

--- a/docs/provisioning-state-must-be-read-only.md
+++ b/docs/provisioning-state-must-be-read-only.md
@@ -41,11 +41,13 @@ provisioningState without readOnly
     "FooProps": {
       "properties": {
         "provisioningState": {
-          "type": "string",
-          "description": "Provisioning state of the foo rule.",
-          "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+            "$ref": "#/definitions/ProvisioningState"
         },
       },
+    },
+   "ProvisioningState": {
+      "type": "string",
+      "enum": ["Succeeded", "Failed", "Canceled"],
     },
 }
 ```
@@ -147,10 +149,6 @@ provisioningState with readOnly defined in the actual definition
       "type": "string",
       "readOnly": true,
       "enum": ["Succeeded", "Failed", "Canceled"],
-      "x-ms-enum": {
-        "name": "ProvisioningState",
-        "modelAsString": true,
-      },
     },
     "FooRule": {
       "type": "object",

--- a/docs/provisioning-state-must-be-read-only.md
+++ b/docs/provisioning-state-must-be-read-only.md
@@ -41,13 +41,11 @@ provisioningState without readOnly
     "FooProps": {
       "properties": {
         "provisioningState": {
-            "$ref": "#/definitions/ProvisioningState"
+          "type": "string",
+          "description": "Provisioning state of the foo rule.",
+          "enum": ["Creating", "Canceled", "Deleting", "Failed"],
         },
       },
-    },
-   "ProvisioningState": {
-      "type": "string",
-      "enum": ["Succeeded", "Failed", "Canceled"],
     },
 }
 ```
@@ -89,11 +87,8 @@ provisioningState with readOnly defined in the envelope property and not in the 
     "FooProps": {
       "properties": {
         "provisioningState": {
-        "$ref": "#/definitions/ProvisioningState",
-        "readOnly": true,
-        "type": "string",
-        "description": "Provisioning state of the foo rule.",
-        "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+            "$ref": "#/definitions/ProvisioningState",
+            "readOnly": true,
         },
       },
     }
@@ -147,6 +142,7 @@ provisioningState with readOnly defined in the actual definition
 "definitions": {
    "ProvisioningState": {
       "type": "string",
+      "description": "Provisioning state of the foo rule.",
       "readOnly": true,
       "enum": ["Succeeded", "Failed", "Canceled"],
     },
@@ -162,10 +158,7 @@ provisioningState with readOnly defined in the actual definition
     "FooProps": {
       "properties": {
         "provisioningState": {
-        "$ref": "#/definitions/ProvisioningState",
-        "type": "string",
-        "description": "Provisioning state of the foo rule.",
-        "enum": ["Creating", "Canceled", "Deleting", "Failed"],
+          "$ref": "#/definitions/ProvisioningState",
         },
       },
     }

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3056,6 +3056,17 @@ const ruleset = {
                 function: verifyXMSLongRunningOperationProperty,
             },
         },
+        ProvisioningStateMustBeReadOnly: {
+            description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
+            message: "{{error}}",
+            severity: "error",
+            resolved: true,
+            formats: [oas2],
+            given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],
+            then: {
+                function: provisioningStateMustBeReadOnly,
+            },
+        },
         LroErrorContent: {
             description: "Error response content of long running operations must follow the error schema provided in the common types v2 and above.",
             message: "{{description}}",
@@ -3640,17 +3651,6 @@ const ruleset = {
             given: "$..['$ref']",
             then: {
                 function: latestVersionOfCommonTypesMustBeUsed,
-            },
-        },
-        ProvisioningStateMustBeReadOnly: {
-            description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
-            message: "{{error}}",
-            severity: "error",
-            resolved: true,
-            formats: [oas2],
-            given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],
-            then: {
-                function: provisioningStateMustBeReadOnly,
             },
         },
         ArrayMustHaveType: {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -189,6 +189,19 @@ const ruleset: any = {
       },
     },
 
+    // RPC Code: RPC-Async-V1-16
+    ProvisioningStateMustBeReadOnly: {
+      description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
+      message: "{{error}}",
+      severity: "error",
+      resolved: true,
+      formats: [oas2],
+      given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],
+      then: {
+        function: provisioningStateMustBeReadOnly,
+      },
+    },
+
     // RPC Code: RPC-Common-V1-05
     LroErrorContent: {
       description:
@@ -919,17 +932,6 @@ const ruleset: any = {
       given: "$..['$ref']",
       then: {
         function: latestVersionOfCommonTypesMustBeUsed,
-      },
-    },
-    ProvisioningStateMustBeReadOnly: {
-      description: "This is a rule introduced to validate if provisioningState property is set to readOnly or not.",
-      message: "{{error}}",
-      severity: "error",
-      resolved: true,
-      formats: [oas2],
-      given: ["$[paths,'x-ms-paths'].*.*.responses.*.schema"],
-      then: {
-        function: provisioningStateMustBeReadOnly,
       },
     },
     ArrayMustHaveType: {


### PR DESCRIPTION
Folks complain ProvisioningStateMustBeReadOnly flagging false positives, when it isnt. This PR improves the doc to include all the good and bad examples and make docs more clear