### PR TITLE
Fix false positive for NoDuplicatePathsForScopeParameter

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/543-noduplicatepathsforscopeparameter-false-positive_2024-01-11-18-19.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/543-noduplicatepathsforscopeparameter-false-positive_2024-01-11-18-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix a false positive in NoDuplicatePathsForScopeParameter where the rule would flag list and point GETs as the same path",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/docs/no-duplicate-paths-for-scope-parameter.md
+++ b/docs/no-duplicate-paths-for-scope-parameter.md
@@ -14,11 +14,14 @@ ARM OpenAPI(swagger) specs
 
 ## Description
 
-Swagger authors that use the `scope` path parameter to indicate that an API is applicable to various scopes (Tenant, Management Group, Subscription, Resource Group, etc.), must not include API paths with explicitly defined scopes (e.g. a `subscription` path parameter).
+Swagger authors that use the `scope` path parameter to indicate that an API is applicable to various scopes (Tenant,
+Management Group, Subscription, Resource Group, etc.), must not include API paths with explicitly defined scopes (e.g. a
+`subscription` path parameter).
 
 ## How to fix
 
-Either remove the path with the `scope` parameter, or remove all explicitly-scoped paths that duplicate the path with the `scope` parameter.
+Either remove the path with the `scope` parameter, or remove all explicitly-scoped paths that duplicate the path with
+the `scope` parameter.
 
 Example of duplicate paths:
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -612,7 +612,9 @@ Please refer to [next-link-property-must-exist.md](./next-link-property-must-exi
 
 ### NoDuplicatePathsForScopeParameter
 
-Swagger authors that use the `scope` path parameter to indicate that an API is applicable to various scopes (Tenant, Management Group, Subscription, Resource Group, etc.), must not include API paths with explicitly defined scopes (e.g. a `subscription` path parameter).
+Swagger authors that use the `scope` path parameter to indicate that an API is applicable to various scopes (Tenant,
+Management Group, Subscription, Resource Group, etc.), must not include API paths with explicitly defined scopes (e.g. a
+`subscription` path parameter).
 
 Please refer to [no-duplicate-paths-for-scope-parameter.md](./no-duplicate-paths-for-scope-parameter.md) for details.
 
@@ -1033,13 +1035,13 @@ Please refer to [put-response-codes.md](./put-response-codes.md) for details.
 
 ### RepeatedPathInfo
 
-The '{property name}' already appears in the URI, please don't repeat it in the request body. Information in the URI must not be repeated in the request body (i.e. subscription ID, resource group name, resource name).
+Information in the URI must not be repeated in the request body (i.e. subscription ID, resource group name, resource name).
 
 Please refer to [repeated-path-info.md](./repeated-path-info.md) for details.
 
 ### RequestBodyMustExistForPutPatch
 
-A PUT or Patch request must always have a request body defined. This rule applies to all ARM resources (Tracked and proxy). PUT and patch operations using an empty payload is not allowed in ARM.
+A PUT or PATCH request must always have a request body defined. This rule applies to all ARM resources (Tracked and Proxy). PUT and PATCH operations using an empty payload is not allowed in ARM.
 
 Please refer to [request-body-must-exist-for-put-patch.md](./request-body-must-exist-for-put-patch.md) for details.
 
@@ -1280,7 +1282,7 @@ Please refer to [tracked-resource-patch-operation.md](./tracked-resource-patch-o
 
 ### TrackedResourceSchemaTags
 
-Every tracked resource MUST support tags as an optional property. The specified tracked resource either does not have tags mentioned as a property or it is mentioned but marked as required.
+Every tracked resource **must** support tags as an **optional** property. The specified tracked resource either does not have 'tags' as a property or has 'tags' marked as required.
 
 Please refer to [tracked-resource-schema-tags.md](./tracked-resource-schema-tags.md) for details.
 

--- a/packages/rulesets/src/spectral/functions/no-duplicate-paths-for-scope-parameter.ts
+++ b/packages/rulesets/src/spectral/functions/no-duplicate-paths-for-scope-parameter.ts
@@ -11,7 +11,7 @@ const noDuplicatePathsForScopeParameter = (path: any, _opts: any, ctx: any) => {
     return []
   }
 
-  const pathRegEx = new RegExp(path.replace(scopeParameter, ".*"))
+  const pathRegEx = new RegExp(path.replace(scopeParameter, ".*").concat("$"))
 
   // check each explicitly-scoped path to see if it is already defined by the variably-scoped path
   const otherPaths = Object.keys(swagger.paths).filter((p: string) => p !== path)

--- a/packages/rulesets/src/spectral/test/no-duplicate-paths-for-scope-parameter.test.ts
+++ b/packages/rulesets/src/spectral/test/no-duplicate-paths-for-scope-parameter.test.ts
@@ -353,3 +353,32 @@ test("NoDuplicatePathsForScopeParameter should find errors for other scopes", ()
     expect(results[2].message).toContain(`"${paths[0]}" that has the scope parameter`)
   })
 })
+
+test("NoDuplicatePathsForScopeParameter should not find errors for list and point get paths", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/{scope}/providers/Microsoft.Bakery/breads": {
+        get: {
+          parameters: [{ $ref: "#/parameters/ScopeParameter" }],
+        },
+      },
+      "/{scope}/providers/Microsoft.Bakery/breads/{breadName}": {
+        get: {
+          parameters: [{ $ref: "#/parameters/ScopeParameter" }],
+        },
+      },
+    },
+    parameters: {
+      ScopeParameter: {
+        name: "scope",
+        in: "path",
+        required: true,
+      },
+    },
+  }
+
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
`/{scope}/providers/Microsoft.Security/customRecommendations/{customRecommendationName}` and `/{scope}/providers/Microsoft.Security/customRecommendations` are identified as duplicated paths.

Added a `$` to the end of the regex to make the match more accurate.