### PR TITLE
Tejaswis/fps properties type object no definition

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-FPSPropertiesTypeObjectNoDefinition_2024-01-22-23-22.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-FPSPropertiesTypeObjectNoDefinition_2024-01-22-23-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix an issue where PropertiesTypeObjectNoDefinition must verify the existence of the allOf property in the definition object.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2352,8 +2352,9 @@ const propertiesTypeObjectNoDefinition = (definitionObject, opts, ctx) => {
         return [{ message: errorMessageNull, path }];
     }
     if (typeof definitionObject === "object") {
-        if (definitionObject.allOf)
+        if (definitionObject.allOf) {
             return;
+        }
         if (definitionObject.properties === undefined) {
             if (definitionObject.additionalProperties === undefined) {
                 return [{ message: errorMessageObject, path }];

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2352,6 +2352,8 @@ const propertiesTypeObjectNoDefinition = (definitionObject, opts, ctx) => {
         return [{ message: errorMessageNull, path }];
     }
     if (typeof definitionObject === "object") {
+        if (definitionObject.allOf)
+            return;
         if (definitionObject.properties === undefined) {
             if (definitionObject.additionalProperties === undefined) {
                 return [{ message: errorMessageObject, path }];

--- a/packages/rulesets/src/spectral/functions/properties-type-object-no-definition.ts
+++ b/packages/rulesets/src/spectral/functions/properties-type-object-no-definition.ts
@@ -19,7 +19,9 @@ export const propertiesTypeObjectNoDefinition: any = (definitionObject: any, opt
   }
 
   if (typeof definitionObject === "object") {
-    if (definitionObject.allOf) return
+    if (definitionObject.allOf) {
+      return
+    }
     if (definitionObject.properties === undefined) {
       if (definitionObject.additionalProperties === undefined) {
         return [{ message: errorMessageObject, path }]

--- a/packages/rulesets/src/spectral/functions/properties-type-object-no-definition.ts
+++ b/packages/rulesets/src/spectral/functions/properties-type-object-no-definition.ts
@@ -19,6 +19,7 @@ export const propertiesTypeObjectNoDefinition: any = (definitionObject: any, opt
   }
 
   if (typeof definitionObject === "object") {
+    if (definitionObject.allOf) return
     if (definitionObject.properties === undefined) {
       if (definitionObject.additionalProperties === undefined) {
         return [{ message: errorMessageObject, path }]

--- a/packages/rulesets/src/spectral/test/properties-type-object-no-definition.test.ts
+++ b/packages/rulesets/src/spectral/test/properties-type-object-no-definition.test.ts
@@ -220,12 +220,11 @@ test("PropertiesTypeObjectNoDefinition should find no errors", () => {
         description:
           "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
         type: "object",
-        properties: {
-          error: {
-            description: "The error object.",
-            $ref: "#/definitions/ErrorDetail",
+        allOf: [
+          {
+            $ref: "#/definitions/ErrorAdditionalInfo",
           },
-        },
+        ],
       },
       ErrorAdditionalInfo: {
         type: "object",

--- a/packages/rulesets/src/spectral/test/properties-type-object-no-definition.test.ts
+++ b/packages/rulesets/src/spectral/test/properties-type-object-no-definition.test.ts
@@ -220,11 +220,12 @@ test("PropertiesTypeObjectNoDefinition should find no errors", () => {
         description:
           "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
         type: "object",
-        allOf: [
-          {
-            $ref: "#/definitions/ErrorAdditionalInfo",
+        properties: {
+          error: {
+            description: "The error object.",
+            $ref: "#/definitions/ErrorDetail",
           },
-        ],
+        },
       },
       ErrorAdditionalInfo: {
         type: "object",
@@ -283,6 +284,49 @@ test("PropertiesTypeObjectNoDefinition should find no errors", () => {
             type: "string",
           },
           description: "The additional info.",
+        },
+        description: "The resource management error additional info.",
+      },
+    },
+  }
+  return linter.run(oasDoc1).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("PropertiesTypeObjectNoDefinition should find no errors for type allOf", () => {
+  const oasDoc1 = {
+    swagger: "2.0",
+    info: {
+      version: "4.0",
+      title: "Common types",
+    },
+    paths: {},
+    definitions: {
+      ErrorResponse: {
+        title: "Error response",
+        description:
+          "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+        type: "object",
+        allOf: [
+          {
+            $ref: "#/definitions/ErrorAdditionalInfo",
+          },
+        ],
+      },
+      ErrorAdditionalInfo: {
+        type: "object",
+        properties: {
+          type: {
+            readOnly: true,
+            type: "string",
+            description: "The additional info type.",
+          },
+          info: {
+            readOnly: true,
+            type: "string",
+            description: "The additional info.",
+          },
         },
         description: "The resource management error additional info.",
       },


### PR DESCRIPTION
PropertiesTypeObjectNoDefinition must verify the existence of the "allOf" property in the definition object, previously the rule wasn't checking this condition which resulted to false positives.

WI - https://msazure.visualstudio.com/One/_workitems/edit/26124716