### PR TITLE
Fix ParameterNotUsingCommonTypes rule

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-fps-ParameterNotUsingCommonTypes_2024-01-24-18-56.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-fps-ParameterNotUsingCommonTypes_2024-01-24-18-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix an issue where ParameterNotUsingCommonTypes rule concatenates all the calls on a path instead of verifying individual GET/POST/PUT/DELETE call, these changes modify the rule accordingly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-fps-ParameterNotUsingCommonTypes_2024-01-24-18-56.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/tejaswis-fps-ParameterNotUsingCommonTypes_2024-01-24-18-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft.azure/openapi-validator-rulesets",
-      "comment": "Fix an issue where ParameterNotUsingCommonTypes rule concatenates all the calls on a path instead of verifying individual GET/POST/PUT/DELETE call, these changes modify the rule accordingly",
+      "comment": "Fix a false alarm with the ParameterNotUsingCommonTypes rule that resulted in errors being flagged even when common-types were being referenced correctly.",
       "type": "patch"
     }
   ],

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1955,12 +1955,8 @@ const parameterNotDefinedInGlobalParameters = (parameters, _opts, ctx) => {
     return errors;
 };
 
-const parameterNotUsingCommonTypes = (parameters, _opts, ctx) => {
-    var _a, _b;
-    if (parameters === null || !Array.isArray(parameters)) {
-        return [];
-    }
-    if (parameters.length === 0) {
+const parameterNotUsingCommonTypes = (parametersName, _opts, ctx) => {
+    if (parametersName === null) {
         return [];
     }
     const commonTypesParametersNames = new Set([
@@ -1975,17 +1971,15 @@ const parameterNotUsingCommonTypes = (parameters, _opts, ctx) => {
         "ifMatch",
         "ifNoneMatch",
     ]);
-    const swagger = (_a = ctx === null || ctx === void 0 ? void 0 : ctx.documentInventory) === null || _a === void 0 ? void 0 : _a.resolved;
-    const allParams = parameters.concat(Object.values((_b = swagger === null || swagger === void 0 ? void 0 : swagger.parameters) !== null && _b !== void 0 ? _b : []));
-    const paramsWithNameProperty = allParams.filter((param) => Object.keys(param).includes("name"));
-    const paramNames = paramsWithNameProperty.map((param) => param.name);
-    const paramsFromCommonTypes = paramNames.filter((pName) => commonTypesParametersNames.has(pName));
-    const errors = paramsFromCommonTypes.map((pName) => {
-        return {
-            message: `Not using the common-types defined parameter "${pName}".`,
-            path: ctx.path,
-        };
-    });
+    const errors = [];
+    const path = ctx.path;
+    const checkCommonTypes = commonTypesParametersNames.has(parametersName);
+    if (checkCommonTypes) {
+        errors.push({
+            message: `Not using the common-types defined parameter "${parametersName}".`,
+            path: path,
+        });
+    }
     return errors;
 };
 
@@ -3741,7 +3735,7 @@ const ruleset = {
             severity: "warn",
             resolved: false,
             formats: [oas2],
-            given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'parameters')]"],
+            given: ["$[paths,'x-ms-paths'].*.*.parameters.*.name", "$[parameters].*.name"],
             then: {
                 function: parameterNotUsingCommonTypes,
             },

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -1019,7 +1019,7 @@ const ruleset: any = {
       severity: "warn",
       resolved: false,
       formats: [oas2],
-      given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'parameters')]"],
+      given: ["$[paths,'x-ms-paths'].*.*.parameters.*.name", "$[parameters].*.name"],
       then: {
         function: parameterNotUsingCommonTypes,
       },

--- a/packages/rulesets/src/spectral/functions/parameter-not-using-common-types.ts
+++ b/packages/rulesets/src/spectral/functions/parameter-not-using-common-types.ts
@@ -1,10 +1,7 @@
 // Verifies that parameters already defined in common-types are not being redefined.
 
-export const parameterNotUsingCommonTypes = (parameters: any, _opts: any, ctx: any) => {
-  if (parameters === null || !Array.isArray(parameters)) {
-    return []
-  }
-  if (parameters.length === 0) {
+export const parameterNotUsingCommonTypes = (parametersName: any, _opts: any, ctx: any) => {
+  if (parametersName === null) {
     return []
   }
 
@@ -21,18 +18,15 @@ export const parameterNotUsingCommonTypes = (parameters: any, _opts: any, ctx: a
     "ifNoneMatch",
   ])
 
-  const swagger = ctx?.documentInventory?.resolved
+  const errors = []
+  const path = ctx.path
 
-  const allParams = parameters.concat(Object.values(swagger?.parameters ?? []))
-  const paramsWithNameProperty = allParams.filter((param) => Object.keys(param).includes("name"))
-  const paramNames = paramsWithNameProperty.map((param) => param.name)
-  const paramsFromCommonTypes = paramNames.filter((pName) => commonTypesParametersNames.has(pName))
-  const errors = paramsFromCommonTypes.map((pName) => {
-    return {
-      message: `Not using the common-types defined parameter "${pName}".`,
-      path: ctx.path,
-    }
-  })
-
+  const checkCommonTypes = commonTypesParametersNames.has(parametersName)
+  if (checkCommonTypes) {
+    errors.push({
+      message: `Not using the common-types defined parameter "${parametersName}".`,
+      path: path,
+    })
+  }
   return errors
 }

--- a/packages/rulesets/src/spectral/test/parameter-not-using-common-types.test.ts
+++ b/packages/rulesets/src/spectral/test/parameter-not-using-common-types.test.ts
@@ -37,6 +37,23 @@ test("ParameterNotUsingCommonTypes should find errors path parameters", () => {
             },
           },
         },
+        put: {
+          operationId: "Path_Put",
+          parameters: [
+            {
+              name: "api-version",
+              in: "path",
+              required: true,
+              type: "string",
+              description: "test location",
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
       },
     },
     parameters: {
@@ -50,11 +67,13 @@ test("ParameterNotUsingCommonTypes should find errors path parameters", () => {
     },
   }
   const ret = nonResolvingLinter.run(myOpenApiDocument).then((results) => {
-    expect(results.length).toBe(2)
-    expect(results[0].path.join(".")).toBe("paths./api/Paths.get.parameters")
-    expect(results[0].message).toContain("location")
-    expect(results[1].path.join(".")).toBe("paths./api/Paths.get.parameters")
-    expect(results[1].message).toContain("scope")
+    expect(results.length).toBe(3)
+    expect(results[0].path.join(".")).toBe("paths./api/Paths.get.parameters.0.name")
+    expect(results[0].message).toContain('Not using the common-types defined parameter "location".')
+    expect(results[1].path.join(".")).toBe("paths./api/Paths.get.parameters.1.name")
+    expect(results[1].message).toContain('Not using the common-types defined parameter "scope".')
+    expect(results[2].path.join(".")).toBe("paths./api/Paths.put.parameters.0.name")
+    expect(results[2].message).toContain('Not using the common-types defined parameter "api-version".')
   })
   return ret
 })
@@ -70,6 +89,19 @@ test("ParameterNotUsingCommonTypes should find errors global parameters", () => 
             {
               $ref: "#/parameters/SubscriptionIdParameter",
             },
+            {
+              $ref: "#/parameters/ApiVersionParameter",
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+        put: {
+          operationId: "Path_Put",
+          parameters: [
             {
               $ref: "#/parameters/ApiVersionParameter",
             },
@@ -101,10 +133,10 @@ test("ParameterNotUsingCommonTypes should find errors global parameters", () => 
   }
   return nonResolvingLinter.run(myOpenApiDocument).then((results) => {
     expect(results.length).toBe(2)
-    expect(results[0].path.join(".")).toBe("paths./api/Paths.get.parameters")
-    expect(results[0].message).toContain("subscriptionId")
-    expect(results[1].path.join(".")).toBe("paths./api/Paths.get.parameters")
-    expect(results[1].message).toContain("api-version")
+    expect(results[0].path.join(".")).toBe("parameters.SubscriptionIdParameter.name")
+    expect(results[0].message).toContain('Not using the common-types defined parameter "subscriptionId".')
+    expect(results[1].path.join(".")).toBe("parameters.ApiVersionParameter.name")
+    expect(results[1].message).toContain('Not using the common-types defined parameter "api-version".')
   })
 })
 
@@ -124,6 +156,13 @@ test("ParameterNotUsingCommonTypes should find no errors", () => {
             },
             {
               $ref: "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter",
+            },
+            {
+              name: "testScope",
+              in: "path",
+              required: true,
+              type: "string",
+              description: "test scope",
             },
           ],
           responses: {


### PR DESCRIPTION
The existed ParameterNotUsingCommonTypes rule concatenates all the calls on a path instead of verifying individual GET/POST/PUT/DELETE call

Modified the rules to check each call separately and added a condition which checks all the parameters defined under $.paths and $.parameters 

https://msazure.visualstudio.com/One/_workitems/edit/26378654