### PR TITLE
Fix patch body schema

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/fix-patch-body-schema_2024-02-23-01-08.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/fix-patch-body-schema_2024-02-23-01-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix PatchBodyParametersSchema https://github.com/Azure/azure-openapi-validator/pull/661",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2028,7 +2028,7 @@ const parametersInPost = (postParameters, _opts, ctx) => {
     return errors;
 };
 
-const pathBodyParameters = (parameters, _opts, paths) => {
+const patchBodyParameters = (parameters, _opts, paths) => {
     if (parameters === null || parameters.schema === undefined || parameters.in !== "body") {
         return [];
     }
@@ -2040,20 +2040,20 @@ const pathBodyParameters = (parameters, _opts, paths) => {
         if (properties[prop].default) {
             errors.push({
                 message: `Properties of a PATCH request body must not have default value, property:${prop}.`,
-                path: [...path, "schema"]
+                path: [...path, "schema"],
             });
         }
         if (requiredProperties.includes(prop)) {
             errors.push({
                 message: `Properties of a PATCH request body must not be required, property:${prop}.`,
-                path: [...path, "schema"]
+                path: [...path, "schema"],
             });
         }
-        const xmsMutability = properties[prop]['x-ms-mutability'];
+        const xmsMutability = properties[prop]["x-ms-mutability"];
         if (xmsMutability && xmsMutability.length === 1 && xmsMutability[0] === "create") {
             errors.push({
                 message: `Properties of a PATCH request body must not be x-ms-mutability: ["create"], property:${prop}.`,
-                path: [...path, "schema"]
+                path: [...path, "schema"],
             });
         }
     }
@@ -3330,7 +3330,7 @@ const ruleset = {
             formats: [oas2],
             given: ["$.paths.*.patch.parameters[?(@.in === 'body')]"],
             then: {
-                function: pathBodyParameters,
+                function: patchBodyParameters,
             },
         },
         PatchIdentityProperty: {

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2056,6 +2056,12 @@ const patchBodyParameters = (parameters, _opts, paths) => {
                 path: [...path, "schema"],
             });
         }
+        if (properties[prop].type === "object" || (properties[prop].type === undefined && properties[prop].properties)) {
+            errors.push(...patchBodyParameters({
+                schema: properties[prop],
+                in: "body",
+            }, _opts, { path: [...path, "schema", "properties", prop] }));
+        }
     }
     return errors;
 };

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -28,7 +28,7 @@ import { parameterNotDefinedInGlobalParameters } from "./functions/parameter-not
 import { parameterNotUsingCommonTypes } from "./functions/parameter-not-using-common-types"
 import { parametersInPointGet } from "./functions/parameters-in-point-get"
 import { parametersInPost } from "./functions/parameters-in-post"
-import pathBodyParameters from "./functions/patch-body-parameters"
+import patchBodyParameters from "./functions/patch-body-parameters"
 import { patchPropertiesCorrespondToPutProperties } from "./functions/patch-properties-correspond-to-put-properties"
 import { patchResponseCodes } from "./functions/patch-response-codes"
 import pathForTrackedResourceTypes from "./functions/path-for-tracked-resource-types"
@@ -535,7 +535,7 @@ const ruleset: any = {
       formats: [oas2],
       given: ["$.paths.*.patch.parameters[?(@.in === 'body')]"],
       then: {
-        function: pathBodyParameters,
+        function: patchBodyParameters,
       },
     },
     // RPC Code: RPC-Patch-V1-11

--- a/packages/rulesets/src/spectral/functions/patch-body-parameters.ts
+++ b/packages/rulesets/src/spectral/functions/patch-body-parameters.ts
@@ -1,38 +1,37 @@
-import { getProperties, getRequiredProperties } from "./utils";
+import { getProperties, getRequiredProperties } from "./utils"
 
-//This rule appears if in the patch body parameters have properties which is marked as required or x-ms-mutibility:["create"] or have default
-const pathBodyParameters = (parameters:any, _opts:any, paths:any) => {
+//This rule appears if in the patch body parameters have properties which is marked as required or x-ms-mutability:["create"] or have default
+const patchBodyParameters = (parameters: any, _opts: any, paths: any) => {
   if (parameters === null || parameters.schema === undefined || parameters.in !== "body") {
-    return [];
+    return []
   }
-  const path = paths.path || [];
+  const path = paths.path || []
 
-  const properties: object = getProperties(parameters.schema);
+  const properties: object = getProperties(parameters.schema)
   const requiredProperties = getRequiredProperties(parameters.schema)
   const errors = []
-  for (const prop of Object.keys(properties)) 
-  {
+  for (const prop of Object.keys(properties)) {
     if (properties[prop].default) {
       errors.push({
         message: `Properties of a PATCH request body must not have default value, property:${prop}.`,
-        path: [...path,"schema"]
+        path: [...path, "schema"],
       })
     }
     if (requiredProperties.includes(prop)) {
       errors.push({
         message: `Properties of a PATCH request body must not be required, property:${prop}.`,
-        path: [...path,"schema"]
+        path: [...path, "schema"],
       })
     }
-    const xmsMutability = properties[prop]['x-ms-mutability']
+    const xmsMutability = properties[prop]["x-ms-mutability"]
     if (xmsMutability && xmsMutability.length === 1 && xmsMutability[0] === "create") {
       errors.push({
         message: `Properties of a PATCH request body must not be x-ms-mutability: ["create"], property:${prop}.`,
-        path: [...path,"schema"]
+        path: [...path, "schema"],
       })
     }
   }
   return errors
-};
+}
 
-export default pathBodyParameters
+export default patchBodyParameters

--- a/packages/rulesets/src/spectral/test/patch-body-parameters.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-body-parameters.test.ts
@@ -1,159 +1,156 @@
-import { Spectral } from '@stoplight/spectral-core';
-import linterForRule from './utils';
+import { Spectral } from "@stoplight/spectral-core"
+import linterForRule from "./utils"
 
-let linter:Spectral;
+let linter: Spectral
 
 beforeAll(async () => {
-  linter = await linterForRule('PatchBodyParametersSchema');
-  return linter;
-});
+  linter = await linterForRule("PatchBodyParametersSchema")
+  return linter
+})
 
-test('PatchBodyParametersSchema should find errors for default value body parameter', () => {
+test("PatchBodyParametersSchema should find errors for default value body parameter", () => {
   const oasDoc = {
-    "swagger": "2.0",
-    "paths": {
-        "/foo": {
-            "patch": {
-                "tags": [ "SampleTag" ],
-                "operationId": "Foo_Update",
-                "description": "Test Description",
-                "parameters": [
-                  {
-                    "name": "foo_patch",
-                    "in": "body",
-                    "schema": {
-                      "$ref": "#/definitions/FooRequestParams"
-                    },
-                  }
-                ],
-                "responses": {
-                }
-            }
-        }
-    },
-    "definitions": {
-      "FooRequestParams": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/FooProps"
-          }
-        ]
-      },
-      "FooProps": {
-        "properties": {
-          "prop0": {
-            "type": "string",
-            "default": "my def val"
-          }
-        }
-      }
-    }
-  };
-  return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(1);
-    expect(results[0].path.join('.')).toBe('paths./foo.patch.parameters.0.schema');
-    expect(results[0].message).toContain('Properties of a PATCH request body must not have default value, property:prop0.');
-  });
-});
-
-test('PatchBodyParametersSchema should find errors for required/create value', () => {
-  const oasDoc = {
-    "swagger": "2.0",
-    "paths": {
-        "/foo": {
-            "patch": {
-                "tags": [ "SampleTag" ],
-                "operationId": "Foo_Update",
-                "description": "Test Description",
-                "parameters": [
-                  {
-                    "name": "foo_patch",
-                    "in": "body",
-                    "schema": {
-                      "$ref": "#/definitions/FooRequestParams"
-                    },
-                  }
-                ],
-                "responses": {
-                }
-            }
-        }
-    },
-    "definitions": {
-      "FooRequestParams": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/FooProps"
-          }
-        ]
-      },
-      "FooProps": {
-        "properties": {
-          "prop0": {
-            "type": "string",
-          },
-          "prop1": {
-            "type": "string",
-            "x-ms-mutability": ["create"]
-          }
+    swagger: "2.0",
+    paths: {
+      "/foo": {
+        patch: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Update",
+          description: "Test Description",
+          parameters: [
+            {
+              name: "foo_patch",
+              in: "body",
+              schema: {
+                $ref: "#/definitions/FooRequestParams",
+              },
+            },
+          ],
+          responses: {},
         },
-        required:["prop0"]
-      }
-    }
-  };
-  return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(2);
-    expect(results[0].path.join('.')).toBe('paths./foo.patch.parameters.0.schema');
-    expect(results[0].message).toContain('Properties of a PATCH request body must not be required, property:prop0.');
-    expect(results[1].path.join('.')).toBe('paths./foo.patch.parameters.0.schema');
-    expect(results[1].message).toContain('Properties of a PATCH request body must not be x-ms-mutability: ["create"], property:prop1.');
-  });
-});
-
-test('PatchBodyParametersSchema should find no errors', () => {
-  const oasDoc = {
-    "swagger": "2.0",
-    "paths": {
-        "/foo": {
-            "patch": {
-                "tags": [ "SampleTag" ],
-                "operationId": "Foo_Update",
-                "description": "Test Description",
-                "parameters": [
-                  {
-                    "name": "foo_patch",
-                    "in": "body",
-                    "schema": {
-                      "$ref": "#/definitions/FooRequestParams"
-                    },
-                  }
-                ],
-                "responses": {
-                }
-            }
-        }
-    },
-    "definitions": {
-      "FooRequestParams": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/FooProps"
-          }
-        ]
       },
-      "FooProps": {
-        "properties": {
-          "prop0": {
-            "type": "string",
+    },
+    definitions: {
+      FooRequestParams: {
+        allOf: [
+          {
+            $ref: "#/definitions/FooProps",
           },
-          "prop1": {
-            "type": "string"
-          }
+        ],
+      },
+      FooProps: {
+        properties: {
+          prop0: {
+            type: "string",
+            default: "my def val",
+          },
         },
-      }
-    }
-  };
+      },
+    },
+  }
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(0);
-  });
-});
+    expect(results.length).toBe(1)
+    expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0.schema")
+    expect(results[0].message).toContain("Properties of a PATCH request body must not have default value, property:prop0.")
+  })
+})
+
+test("PatchBodyParametersSchema should find errors for required/create value", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/foo": {
+        patch: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Update",
+          description: "Test Description",
+          parameters: [
+            {
+              name: "foo_patch",
+              in: "body",
+              schema: {
+                $ref: "#/definitions/FooRequestParams",
+              },
+            },
+          ],
+          responses: {},
+        },
+      },
+    },
+    definitions: {
+      FooRequestParams: {
+        allOf: [
+          {
+            $ref: "#/definitions/FooProps",
+          },
+        ],
+      },
+      FooProps: {
+        properties: {
+          prop0: {
+            type: "string",
+          },
+          prop1: {
+            type: "string",
+            "x-ms-mutability": ["create"],
+          },
+        },
+        required: ["prop0"],
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(2)
+    expect(results[0].path.join(".")).toBe("paths./foo.patch.parameters.0.schema")
+    expect(results[0].message).toContain("Properties of a PATCH request body must not be required, property:prop0.")
+    expect(results[1].path.join(".")).toBe("paths./foo.patch.parameters.0.schema")
+    expect(results[1].message).toContain('Properties of a PATCH request body must not be x-ms-mutability: ["create"], property:prop1.')
+  })
+})
+
+test("PatchBodyParametersSchema should find no errors", () => {
+  const oasDoc = {
+    swagger: "2.0",
+    paths: {
+      "/foo": {
+        patch: {
+          tags: ["SampleTag"],
+          operationId: "Foo_Update",
+          description: "Test Description",
+          parameters: [
+            {
+              name: "foo_patch",
+              in: "body",
+              schema: {
+                $ref: "#/definitions/FooRequestParams",
+              },
+            },
+          ],
+          responses: {},
+        },
+      },
+    },
+    definitions: {
+      FooRequestParams: {
+        allOf: [
+          {
+            $ref: "#/definitions/FooProps",
+          },
+        ],
+      },
+      FooProps: {
+        properties: {
+          prop0: {
+            type: "string",
+          },
+          prop1: {
+            type: "string",
+          },
+        },
+      },
+    },
+  }
+  return linter.run(oasDoc).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR fixes the PatchBodyParametersSchema rule to check nested properties.

Includes tests.

Some format and spelling errors corrected as well, but done in a separate commit.

Fixes Azure/azure-sdk-tools#7701