### PR TITLE
Disable LintDiff rules for TypeSpec 0.55

### DIFF
--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -93,6 +93,8 @@ const ruleset: any = {
       rpcGuidelineCode: "RPC-Async-V1-01, RPC-Put-V1-11",
       description: "LRO and Synchronous PUT must have 200 & 201 return codes.",
       severity: "error",
+      disableForTypeSpec: true,
+      disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes' rule.",
       message: "{{error}}",
       resolved: true,
       formats: [oas2],
@@ -157,6 +159,8 @@ const ruleset: any = {
       description: "Location header must be supported for all async operations that return 202.",
       message: "A 202 response should include an Location response header.",
       severity: "error",
+      disableForTypeSpec: true,
+      disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/arm-location-header' rule.",
       formats: [oas2],
       given: "$.paths[*][*].responses[?(@property == '202')]",
       then: {
@@ -173,6 +177,8 @@ const ruleset: any = {
       description:
         "Synchronous POST must have either 200 or 204 return codes and LRO POST must have 202 return code. LRO POST should also have a 200 return code only if the final response is intended to have a schema",
       severity: "error",
+      disableForTypeSpec: true,
+      disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/arm-post-operation-response-codes' rule.",
       message: "{{error}}",
       resolved: true,
       formats: [oas2],

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -798,6 +798,8 @@ const ruleset: any = {
       description: "This rule ensures that the authors explicitly define these restrictions as a regex on the resource name.",
       message: "{{error}}",
       severity: "error",
+      disableForTypeSpec: true,
+      disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/arm-resource-name-pattern' rule.",
       resolved: true,
       formats: [oas2],
       given: "$[paths,'x-ms-paths'].*.^",

--- a/packages/rulesets/src/spectral/az-common.ts
+++ b/packages/rulesets/src/spectral/az-common.ts
@@ -412,6 +412,8 @@ const ruleset: any = {
       message:
         "'{{property}}' parameter lacks 'description' property. Consider adding a 'description' element. Accurate description is essential for maintaining reference documentation.",
       severity: "error",
+      disableForTypeSpec: true,
+      disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-core/documentation-required' rule.",
       resolved: false,
       formats: [oas2],
       given: ["$.parameters.*"],


### PR DESCRIPTION
Disables the following rules:
- PutResponseCodes
- PostResponseCodes
- ParameterDescriptionRequired
- LroLocationHeader
- ResrouceNameRestriction