### PR TITLE
Add more information to thrown exception if processing native rule fails

### DIFF
--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Azure OpenAPI Validator",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/azure-openapi-validator/autorest/src/openapi-validator-plugin-func.ts
+++ b/packages/azure-openapi-validator/autorest/src/openapi-validator-plugin-func.ts
@@ -56,7 +56,7 @@ export async function openapiValidatorPluginFunc(initiator: IAutoRestPluginIniti
   } catch (e) {
     initiator.Message({
       Channel: "fatal",
-      Text: `openapiValidatorPluginFunc: Failed validating:` + e,
+      Text: `openapiValidatorPluginFunc: Failed validating: ` + e,
     })
   }
 

--- a/packages/azure-openapi-validator/core/package.json
+++ b/packages/azure-openapi-validator/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/azure-openapi-validator/core/src/runner.ts
+++ b/packages/azure-openapi-validator/core/src/runner.ts
@@ -54,31 +54,31 @@ export class LintRunner<T> {
           if (fieldMatch) {
             for (const subSection of nodes(section.value, fieldMatch)) {
               const location: string[] = section.path.slice(1).concat(subSection.path.slice(1))
-              await processRule(rule, subSection.value, location)
+              await processRule(ruleName, rule, subSection.value, targetDefinition, location)
             }
           } else {
             const location: string[] = section.path.slice(1)
-            await processRule(rule, section.value, location)
-          }
-
-          async function processRule(rule: IRule<any>, section: any, location: string[]) {
-            try {
-              const args = getArgs(rule, section, targetDefinition, location)
-              // Note: Legacy rules, like UniqueXmsEnumName, are converted to the 'rule.then.execute' format
-              // via createFromLegacyRules() in packages/rulesets/src/native/rulesets/common.ts
-              for await (const message of (rule.then.execute as any)(...args)) {
-                emitResult(ruleName, rule, message)
-              }
-            } catch (error) {
-              error.message =
-                `azure-openapi-validator/core/src/runner.ts/LintRunner.runRules/processRule error. ` +
-                `ruleName: ${ruleName}, specFilePath: ${document}, ` +
-                `jsonPath: ${convertJsonPath(openapiDefinition, location as string[])}, ` +
-                `errorName: ${error?.name}, errorMessage: ${error?.message}`
-              throw error
-            }
+            await processRule(ruleName, rule, section.value, targetDefinition, location)
           }
         }
+      }
+    }
+
+    async function processRule(ruleName: string, rule: IRule<any>, section: any, targetDefinition: any, location: string[]): Promise<void> {
+      try {
+        const args = getArgs(rule, section, targetDefinition, location)
+        // Note: Legacy rules, like UniqueXmsEnumName, are converted to the 'rule.then.execute' format
+        // via createFromLegacyRules() in packages/rulesets/src/native/rulesets/common.ts
+        for await (const message of (rule.then.execute as any)(...args)) {
+          emitResult(ruleName, rule, message)
+        }
+      } catch (error) {
+        error.message =
+          `azure-openapi-validator/core/src/runner.ts/LintRunner.runRules/processRule error. ` +
+          `ruleName: ${ruleName}, specFilePath: ${document}, ` +
+          `jsonPath: ${convertJsonPath(openapiDefinition, location as string[])}, ` +
+          `errorName: ${error?.name}, errorMessage: ${error?.message}`
+        throw error
       }
     }
 

--- a/packages/azure-openapi-validator/core/src/runner.ts
+++ b/packages/azure-openapi-validator/core/src/runner.ts
@@ -1,11 +1,11 @@
-import { LintCallBack, LintOptions,  } from "./api"
+import { LintCallBack, LintOptions } from "./api"
 import { OpenapiDocument } from "./document"
 import { nodes } from "./jsonpath"
-import { IRuleLoader} from "./ruleLoader"
+import { IRuleLoader } from "./ruleLoader"
 import { SwaggerInventory } from "./swaggerInventory"
-import { OpenApiTypes, ValidationMessage,LintResultMessage , IRule, IRuleSet, RuleScope } from "./types"
+import { OpenApiTypes, ValidationMessage, LintResultMessage, IRule, IRuleSet, RuleScope } from "./types"
 
-import {getRange,convertJsonPath} from "./utils"
+import { getRange, convertJsonPath } from "./utils"
 
 const isLegacyRule = (rule: IRule<any>) => {
   return rule.then.execute.name === "run"
@@ -23,10 +23,12 @@ export class LintRunner<T> {
     inventory: SwaggerInventory,
     scope: RuleScope = "File"
   ) => {
-    const rulesToRun = Object.entries(ruleset.rules).filter(rule => rule[1].openapiType & openapiType && (rule[1].scope || "File")  === scope)
+    const rulesToRun = Object.entries(ruleset.rules).filter(
+      (rule) => rule[1].openapiType & openapiType && (rule[1].scope || "File") === scope
+    )
     const getArgs = (rule: IRule<any>, section: any, doc: any, location: string[]) => {
       if (isLegacyRule(rule)) {
-        return [doc, section, location, { specPath: document, inventory}]
+        return [doc, section, location, { specPath: document, inventory }]
       } else {
         return [
           section,
@@ -35,8 +37,8 @@ export class LintRunner<T> {
             document: doc,
             location,
             specPath: document,
-            inventory
-          }
+            inventory,
+          },
         ]
       }
     }
@@ -48,20 +50,32 @@ export class LintRunner<T> {
       const targetDefinition = openapiDefinition
       for (const given of givens) {
         for (const section of nodes(targetDefinition, given)) {
-          const fiieldMatch = rule.then.fieldMatch
-          if (fiieldMatch) {
-            for (const subSection of nodes(section.value, fiieldMatch)) {
-              const location = section.path.slice(1).concat(subSection.path.slice(1))
-              const args = getArgs(rule, subSection.value, targetDefinition, location)
+          const fieldMatch = rule.then.fieldMatch
+          if (fieldMatch) {
+            for (const subSection of nodes(section.value, fieldMatch)) {
+              const location: string[] = section.path.slice(1).concat(subSection.path.slice(1))
+              await processRule(rule, subSection.value, location)
+            }
+          } else {
+            const location: string[] = section.path.slice(1)
+            await processRule(rule, section.value, location)
+          }
+
+          async function processRule(rule: IRule<any>, section: any, location: string[]) {
+            try {
+              const args = getArgs(rule, section, targetDefinition, location)
+              // Note: Legacy rules, like UniqueXmsEnumName, are converted to the 'rule.then.execute' format
+              // via createFromLegacyRules() in packages/rulesets/src/native/rulesets/common.ts
               for await (const message of (rule.then.execute as any)(...args)) {
                 emitResult(ruleName, rule, message)
               }
-            }
-          } else {
-            const location = section.path.slice(1)
-            const args = getArgs(rule, section.value, targetDefinition, location)
-            for await (const message of (rule.then.execute as any)(...args)) {
-              emitResult(ruleName, rule, message)
+            } catch (error) {
+              error.message =
+                `azure-openapi-validator/core/src/runner.ts/LintRunner.runRules/processRule error. ` +
+                `ruleName: ${ruleName} specFilePath: ${document}, ` +
+                `jsonPath: ${convertJsonPath(openapiDefinition, location as string[])}, ` +
+                `errorMessage: ${error.message}`
+              throw error
             }
           }
         }
@@ -70,22 +84,22 @@ export class LintRunner<T> {
 
     function emitResult(ruleName: string, rule: IRule<any>, message: ValidationMessage) {
       const readableCategory = rule.category
-      const range = getRange(inventory,document,message.location)
-      const msg:LintResultMessage = {
+      const range = getRange(inventory, document, message.location)
+      const msg: LintResultMessage = {
         id: rule.id,
         type: rule.severity,
         category: readableCategory,
         message: message.message,
         code: ruleName,
         sources: [document],
-        jsonpath: convertJsonPath(openapiDefinition,message.location as string[]),
-        range
+        jsonpath: convertJsonPath(openapiDefinition, message.location as string[]),
+        range,
       }
       sendMessage(msg)
     }
   }
 
-  async execute(swaggerPaths: string[], options: LintOptions,cb?:LintCallBack) {
+  async execute(swaggerPaths: string[], options: LintOptions, cb?: LintCallBack) {
     const specsPromises = []
     for (const spec of swaggerPaths) {
       specsPromises.push(this.inventory.loadDocument(spec))
@@ -94,18 +108,17 @@ export class LintRunner<T> {
     const msgs: LintResultMessage[] = []
     const sendMessage = (msg: LintResultMessage) => {
       msgs.push(msg)
-      if (cb){
+      if (cb) {
         cb(msg)
       }
     }
     const runPromises = []
-    let runGlobalRuleFlag = false;
+    let runGlobalRuleFlag = false
     for (const doc of documents) {
-      for (const scope of  ["Global","File"]){
+      for (const scope of ["Global", "File"]) {
         if (scope === "Global" && runGlobalRuleFlag) {
           continue
-        }
-        else {
+        } else {
           runGlobalRuleFlag = true
         }
         const promise = this.runRules(
@@ -114,7 +127,8 @@ export class LintRunner<T> {
           sendMessage,
           options.openapiType,
           await this.loader.getRuleSet(),
-          this.inventory,scope as RuleScope
+          this.inventory,
+          scope as RuleScope
         )
         runPromises.push(promise)
       }
@@ -123,4 +137,3 @@ export class LintRunner<T> {
     return msgs
   }
 }
-

--- a/packages/azure-openapi-validator/core/src/runner.ts
+++ b/packages/azure-openapi-validator/core/src/runner.ts
@@ -72,9 +72,9 @@ export class LintRunner<T> {
             } catch (error) {
               error.message =
                 `azure-openapi-validator/core/src/runner.ts/LintRunner.runRules/processRule error. ` +
-                `ruleName: ${ruleName} specFilePath: ${document}, ` +
+                `ruleName: ${ruleName}, specFilePath: ${document}, ` +
                 `jsonPath: ${convertJsonPath(openapiDefinition, location as string[])}, ` +
-                `errorMessage: ${error.message}`
+                `errorName: ${error?.name}, errorMessage: ${error?.message}`
               throw error
             }
           }


### PR DESCRIPTION
Contributes to:
- https://github.com/Azure/azure-sdk-tools/issues/7612

When I locally injected a failure of invalid call `toLowerCase()` into the native legacy rule of `UniqueXmsEnumName.ts` I got:

```
fatal   | openapiValidatorPluginFunc: Failed validating: TypeError: azure-openapi-validator/core/src/runner.ts/LintRunner.runRules/processRule error. ruleName: UniqueXmsEnumName, specFilePath: file:///C:/Users/username/repos/specs/specification/storage/resource-manager/Microsoft.Storage/stable/2023-01-01/privatelinks.json, jsonPath: definitions, errorName: TypeError, errorMessage: Cannot read properties of undefined (reading 'toLowerCase')
```

Full local execution setup:

``` powershell
$use="C:/Users/username/repos/aov/packages/azure-openapi-validator/autorest"
$apiVersion="package-2023-01"
$autorestConfigFile="C:/Users/username/repos/specs/specification/storage/resource-manager/readme.md"
autorest --v3 --azure-validator --use=$use --tag=$apiVersion $autorestConfigFile
```