### PR TITLE
Disable submodules when cloning repo in pipelines

### DIFF
--- a/azure-pipelines/1es-redirect.yml
+++ b/azure-pipelines/1es-redirect.yml
@@ -28,6 +28,7 @@ extends:
     sdl:
       git:
         longpaths: true
+        submodules: false
       sourceAnalysisPool:
         name: azsdk-pool-mms-win-2022-general
         image: azsdk-pool-mms-win-2022-1espt


### PR DESCRIPTION
- Can cause issues with longpath on Windows
- Submodule is only used for regression tests, which aren't run in pipelines

Verification: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3734614&view=results