### PR TITLE
[AvoidAdditionalProperties] Add null check before dereferencing "@.additionalProperties"

### DIFF
--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3160,7 +3160,7 @@ const ruleset = {
             disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/no-record' rule.",
             resolved: true,
             formats: [oas2],
-            given: "$.definitions..[?(@property !== 'tags' && @property !== 'delegatedResources' && @property !== 'userAssignedIdentities' && @.additionalProperties)]",
+            given: "$.definitions..[?(@property !== 'tags' && @property !== 'delegatedResources' && @property !== 'userAssignedIdentities' && @ && @.additionalProperties)]",
             then: {
                 function: falsy,
             },

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -302,7 +302,7 @@ const ruleset: any = {
       resolved: true,
       formats: [oas2],
       given:
-        "$.definitions..[?(@property !== 'tags' && @property !== 'delegatedResources' && @property !== 'userAssignedIdentities' && @.additionalProperties)]",
+        "$.definitions..[?(@property !== 'tags' && @property !== 'delegatedResources' && @property !== 'userAssignedIdentities' && @ && @.additionalProperties)]",
       then: {
         function: falsy,
       },

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -301,6 +301,7 @@ const ruleset: any = {
       disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/no-record' rule.",
       resolved: true,
       formats: [oas2],
+      // In some cases, variable "@" will be "null" when evaluating the expression, so it must be checked before dereferencing
       given:
         "$.definitions..[?(@property !== 'tags' && @property !== 'delegatedResources' && @property !== 'userAssignedIdentities' && @ && @.additionalProperties)]",
       then: {


### PR DESCRIPTION
- Fixes "TypeError: Cannot read properties of null (reading 'additionalProperties')"
- Fixes #680
