### PR TITLE
Add networksecurityperimeter.json v5 to hardcoded common-types latest versions list

### DIFF
--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -178,6 +178,7 @@ const LATEST_VERSION_BY_COMMON_TYPES_FILENAME = new Map([
     ["privatelinks.json", "v5"],
     ["customermanagedkeys.json", "v5"],
     ["managedidentitywithdelegation.json", "v5"],
+    ["networksecurityperimeter.json", "v5"],
     ["mobo.json", "v5"],
 ]);
 function isLatestCommonTypesVersionForFile(version, fileName) {

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/functions/utils.ts
+++ b/packages/rulesets/src/spectral/functions/utils.ts
@@ -6,6 +6,7 @@ export const LATEST_VERSION_BY_COMMON_TYPES_FILENAME = new Map([
   ["privatelinks.json", "v5"],
   ["customermanagedkeys.json", "v5"],
   ["managedidentitywithdelegation.json", "v5"],
+  ["networksecurityperimeter.json", "v5"],
   ["mobo.json", "v5"],
 ])
 


### PR DESCRIPTION
To fix a spurious warning

>⚠️  LatestVersionOfCommonTypesMustBeUsed | Use the latest version undefined of networksecurityperimeter.json. Location:  Microsoft.OperationalInsights/stable/2021-10-01/Workspaces_NetworkSecurityPerimeter_API.json#L62