### PR TITLE
Fix false alarm for EvenSegmentedPathForPutOperation rule

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_Fix-EvenSegmentedPathForPutOperation_2024-05-28-19-33.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_Fix-EvenSegmentedPathForPutOperation_2024-05-28-19-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix false alarm for EvenSegmentedPathForPutOperation rule",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3400,7 +3400,7 @@ const ruleset = {
             then: {
                 function: pattern,
                 functionOptions: {
-                    match: ".*/providers/\\w+.\\w+(/\\w+/{\\w+})+$",
+                    match: ".*/providers/\\w+.\\w+(/\\w+/(default|{\\w+}))+$",
                 },
             },
         },

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -601,7 +601,8 @@ const ruleset: any = {
       then: {
         function: pattern,
         functionOptions: {
-          match: ".*/providers/\\w+.\\w+(/\\w+/{\\w+})+$",
+          // match: ".*/providers/[\\w\\.]+(?:/\\w+/(default|{\\w+}))*/\\w+$",
+          match: ".*/providers/\\w+.\\w+(/\\w+/(default|{\\w+}))+$",
         },
       },
     },

--- a/packages/rulesets/src/spectral/test/even-segmented-path-for-put-operation.test.ts
+++ b/packages/rulesets/src/spectral/test/even-segmented-path-for-put-operation.test.ts
@@ -106,32 +106,42 @@ test("EvenSegmentedPathForPutOperation should find errors for invalid paths", ()
           responses: {},
         },
       },
+      "/providers/Microsoft.Music/Songs/test": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
     },
   }
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(10)
+    expect(results.length).toBe(11)
     expect(results[0].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music",
     )
     expect(results[1].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs",
     )
     expect(results[2].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist",
     )
     expect(results[3].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/addArtistName"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/addArtistName",
     )
     expect(results[4].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/{artistName}/addSong"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/Artist/{artistName}/addSong",
     )
     expect(results[5].path.join(".")).toBe("paths.{resourceUri}/providers/Microsoft.Music/Songs/{songName}/Artist/{artistName}/addSong")
     expect(results[6].path.join(".")).toBe("paths./{resourceUri}/providers/Microsoft.Music/Songs/{songName}/Artist/{artistName}/addSong")
     expect(results[7].path.join(".")).toBe(
-      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/providers/Microsoft.Album/Albums"
+      "paths./subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}/providers/Microsoft.Album/Albums",
     )
     expect(results[8].path.join(".")).toBe("paths./providers/Microsoft.Music/Songs/{songName}/Artist/{artistName}/addSong")
     expect(results[9].path.join(".")).toBe("paths./providers/Microsoft.Music/Songs")
+    expect(results[10].path.join(".")).toBe("paths./providers/Microsoft.Music/Songs/test")
   })
 })
 
@@ -140,6 +150,15 @@ test("PathForResourceAction should not find errors for valid path", () => {
     swagger: "2.0",
     paths: {
       //valid uri's
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/default": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
       "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Music/Songs/{songName}": {
         put: {
           tags: ["SampleTag"],
@@ -196,6 +215,15 @@ test("PathForResourceAction should not find errors for valid path", () => {
         },
       },
       "/providers/Microsoft.Music/Songs/{songName}": {
+        put: {
+          tags: ["SampleTag"],
+          operationId: "Foo_CreateOrUpdate",
+          description: "Test Description",
+          parameters: [],
+          responses: {},
+        },
+      },
+      "/providers/Microsoft.Music/Songs/default": {
         put: {
           tags: ["SampleTag"],
           operationId: "Foo_CreateOrUpdate",


### PR DESCRIPTION
The rule checks for even segments in the path and in addition checks if the path ends with {} & 
flagged paths like "/providers/Microsoft.PortalServices/copilotSettings/default" which is still valid.

This PR addresses such issues by considering default in addition to the fields ending with {}