### PR TITLE
Fix false alarm for XmsPageableForListCalls rule

### DIFF
--- a/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_XmsPageableForListCalls_false_alarm_2024-05-28-21-28.json
+++ b/common/changes/@microsoft.azure/openapi-validator-rulesets/akhilailla-fix_XmsPageableForListCalls_false_alarm_2024-05-28-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft.azure/openapi-validator-rulesets",
+      "comment": "Fix false alarms for XmsPageableForListCalls rule",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft.azure/openapi-validator-rulesets"
+}

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3250,7 +3250,7 @@ const ruleset = {
             message: "{{error}}",
             resolved: true,
             formats: [oas2],
-            given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}'))].get",
+            given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}') && !@property.endsWith('default'))].get",
             then: {
                 function: xmsPageableForListCalls,
             },

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3250,7 +3250,7 @@ const ruleset = {
             message: "{{error}}",
             resolved: true,
             formats: [oas2],
-            given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}') && !@property.endsWith('default'))].get",
+            given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}') && !@property.endsWith('/default'))].get",
             then: {
                 function: xmsPageableForListCalls,
             },

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -418,8 +418,7 @@ const ruleset: any = {
       message: "{{error}}",
       resolved: true,
       formats: [oas2],
-      //[?(@property === '200' || @property === '201')]
-      given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}') && !@property.endsWith('default'))].get",
+      given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}') && !@property.endsWith('/default'))].get",
       then: {
         function: xmsPageableForListCalls,
       },

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -418,7 +418,8 @@ const ruleset: any = {
       message: "{{error}}",
       resolved: true,
       formats: [oas2],
-      given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}'))].get",
+      //[?(@property === '200' || @property === '201')]
+      given: "$[paths,'x-ms-paths'][?(!@property.endsWith('}') && !@property.endsWith('default'))].get",
       then: {
         function: xmsPageableForListCalls,
       },

--- a/packages/rulesets/src/spectral/test/xms-pageable-for-list-calls.test.ts
+++ b/packages/rulesets/src/spectral/test/xms-pageable-for-list-calls.test.ts
@@ -63,7 +63,7 @@ test("XmsPageableForListCalls should find errors if x-ms-pagebale property is no
     expect(results[0].path.join(".")).toBe("paths./{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine.get")
     expect(results[0].message).toBe(errorMessage)
     expect(results[1].path.join(".")).toBe(
-      "paths./{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine/{virtualMachineInstances}/nestedVirtualMachine.get",
+      "paths./{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine/{virtualMachineInstances}/nestedVirtualMachine.get"
     )
     expect(results[1].message).toBe(errorMessage)
   })

--- a/packages/rulesets/src/spectral/test/xms-pageable-for-list-calls.test.ts
+++ b/packages/rulesets/src/spectral/test/xms-pageable-for-list-calls.test.ts
@@ -63,7 +63,7 @@ test("XmsPageableForListCalls should find errors if x-ms-pagebale property is no
     expect(results[0].path.join(".")).toBe("paths./{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine.get")
     expect(results[0].message).toBe(errorMessage)
     expect(results[1].path.join(".")).toBe(
-      "paths./{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine/{virtualMachineInstances}/nestedVirtualMachine.get"
+      "paths./{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine/{virtualMachineInstances}/nestedVirtualMachine.get",
     )
     expect(results[1].message).toBe(errorMessage)
   })
@@ -73,6 +73,27 @@ test("CollectionObjectPropertiesNaming should find no errors", () => {
   const oasDoc = {
     swagger: "2.0",
     paths: {
+      "/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine/default": {
+        get: {
+          operationId: "Good_List",
+          responses: {
+            200: {
+              description: "Success",
+              schema: {
+                properties: {
+                  value: {
+                    type: "array",
+                  },
+                  nextLink: {
+                    type: "string",
+                  },
+                },
+                required: ["value"],
+              },
+            },
+          },
+        },
+      },
       "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachine": {
         get: {
           operationId: "Good_List",


### PR DESCRIPTION
The rule checks if the list calls have XmsPageableForListCalls  field & hence the logic tries to get all the paths that dont end with "}" &
flags paths like "/providers/Microsoft.PortalServices/copilotSettings/default" which is still valid.

This PR addresses such issues.