### PR TITLE
Moving `release` into `build` yml

### DIFF
--- a/azure-pipelines/1es-redirect.yml
+++ b/azure-pipelines/1es-redirect.yml
@@ -28,7 +28,6 @@ extends:
     sdl:
       git:
         longpaths: true
-        submodules: false
       sourceAnalysisPool:
         name: azsdk-pool-mms-win-2022-general
         image: azsdk-pool-mms-win-2022-1espt

--- a/azure-pipelines/1es-redirect.yml
+++ b/azure-pipelines/1es-redirect.yml
@@ -28,11 +28,15 @@ extends:
     sdl:
       git:
         longpaths: true
+        submodules: false
       sourceAnalysisPool:
         name: azsdk-pool-mms-win-2022-general
         image: azsdk-pool-mms-win-2022-1espt
         os: windows
       sourceRepositoriesToScan:
+        include:
+          - repository: self
+            submodule: false
         exclude:
           - repository: azure-sdk-build-tools
       eslint:

--- a/azure-pipelines/1es-redirect.yml
+++ b/azure-pipelines/1es-redirect.yml
@@ -39,6 +39,7 @@ extends:
             submodule: false
         exclude:
           - repository: azure-sdk-build-tools
+        runInSingleJob: true
       eslint:
         enabled: false
         justificationForDisabling: 'ESLint injected task has failures because it uses an old version of mkdirp. We should not fail for tools not controlled by the repo. See: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3499746'

--- a/azure-pipelines/prod-release-pipelines.yml
+++ b/azure-pipelines/prod-release-pipelines.yml
@@ -39,4 +39,4 @@ extends:
     - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
       - template: /.azure-pipelines/release-stage.yml
         parameters:
-          Version: prod
+          Version: latest

--- a/azure-pipelines/prod-release-pipelines.yml
+++ b/azure-pipelines/prod-release-pipelines.yml
@@ -37,6 +37,6 @@ extends:
               ArtifactPath: $(Build.SourcesDirectory)/dist
 
     - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
-      - template: /.azure-pipelines/release-stage.yml
+      - template: /azure-pipelines/release-stage.yml
         parameters:
           Version: latest

--- a/azure-pipelines/prod-release-pipelines.yml
+++ b/azure-pipelines/prod-release-pipelines.yml
@@ -2,7 +2,7 @@ extends:
   template: /azure-pipelines/1es-redirect.yml
   parameters:
     stages:
-    - stage: Prod_Release
+    - stage: Build
       displayName: Prod Release
 
       variables:
@@ -35,3 +35,8 @@ extends:
             parameters:
               ArtifactName: drop
               ArtifactPath: $(Build.SourcesDirectory)/dist
+
+    - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
+      - template: /.azure-pipelines/release-stage.yml
+        parameters:
+          Version: prod

--- a/azure-pipelines/release-stage.yml
+++ b/azure-pipelines/release-stage.yml
@@ -14,27 +14,36 @@ stages:
     variables:
       - template: /eng/templates/variables/image.yml
 
-    # todo: add an environment for user approval prior to release
-    # todo: grab the ESRP config from azure-sdk-for-js
     jobs:
-      - job: Publish
-
+      - deployment: Publish
+        environment: 'package-publish'
         pool:
-          name: $(LINUXPOOL)
-          image: $(LINUXVMIMAGE) 
+          name: azsdk-pool-mms-ubuntu-2004-general
+          image: azsdk-pool-mms-ubuntu-2004-1espt
           os: linux
 
-        steps:
-          - checkout: self
-            submodules: true
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+              - checkout: self
+                submodules: false
 
-          - download: current
-            artifact: oav
-            timeoutInMinutes: 5
+              - download: current
+                artifact: oav
+                timeoutInMinutes: 5
 
-          - pwsh: |
-              Get-ChildItem $(Build.ArtifactStagingDirectory) -Recurse | % { Write-Host $_.FullName }
+              - task: PowerShell@2
+                inputs:
+                  filePath: '$(Build.SourcesDirectory)/eng/scripts/determine-release-tag.ps1'
+                  failOnStderr: true
+                  pwsh: true
 
+              - pwsh: |
+                  Write-Host "Will deploy with tag of $(Tag)"
+                  Get-ChildItem "$(Pipeline.Workspace)/oav" -Recurse -Force `
+                    | Where-Object { $_.Name -like "*.tgz" } `
+                    | Copy-Item -Destination "$(Build.ArtifactStagingDirectory)"
 
-
-
+                  Get-ChildItem "$(Build.ArtifactStagingDirectory)" -Recurse -Force | % { Write-Host $_.FullName }
+                displayName: Move artifact to $(Build.ArtifactStagingDirectory)

--- a/azure-pipelines/release-stage.yml
+++ b/azure-pipelines/release-stage.yml
@@ -31,7 +31,7 @@ stages:
                 timeoutInMinutes: 5
 
               - pwsh: |
-                  Write-Host "Will deploy with tag of $(Tag)"
+                  Write-Host "Will deploy with tag of ${{ parameters.Version }}"
                   Get-ChildItem "$(Pipeline.Workspace)/drop" -Recurse -Force `
                     | Where-Object { $_.Name -like "*.tgz" } `
                     | Copy-Item -Destination "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines/release-stage.yml
+++ b/azure-pipelines/release-stage.yml
@@ -1,0 +1,40 @@
+parameters:
+  - name: Version
+    type: string
+    default: 'staging'
+    values:
+      - 'staging'
+      - 'prod'
+
+stages:
+  - stage: Release
+    displayName: Release ${{ parameters.Version }}
+    dependsOn: Build
+
+    variables:
+      - template: /eng/templates/variables/image.yml
+
+    # todo: add an environment for user approval prior to release
+    # todo: grab the ESRP config from azure-sdk-for-js
+    jobs:
+      - job: Publish
+
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE) 
+          os: linux
+
+        steps:
+          - checkout: self
+            submodules: true
+
+          - download: current
+            artifact: oav
+            timeoutInMinutes: 5
+
+          - pwsh: |
+              Get-ChildItem $(Build.ArtifactStagingDirectory) -Recurse | % { Write-Host $_.FullName }
+
+
+
+

--- a/azure-pipelines/release-stage.yml
+++ b/azure-pipelines/release-stage.yml
@@ -3,16 +3,13 @@ parameters:
     type: string
     default: 'staging'
     values:
-      - 'staging'
-      - 'prod'
+      - 'beta'
+      - 'latest'
 
 stages:
   - stage: Release
     displayName: Release ${{ parameters.Version }}
     dependsOn: Build
-
-    variables:
-      - template: /eng/templates/variables/image.yml
 
     jobs:
       - deployment: Publish
@@ -30,18 +27,12 @@ stages:
                 submodules: false
 
               - download: current
-                artifact: oav
+                artifact: drop
                 timeoutInMinutes: 5
-
-              - task: PowerShell@2
-                inputs:
-                  filePath: '$(Build.SourcesDirectory)/eng/scripts/determine-release-tag.ps1'
-                  failOnStderr: true
-                  pwsh: true
 
               - pwsh: |
                   Write-Host "Will deploy with tag of $(Tag)"
-                  Get-ChildItem "$(Pipeline.Workspace)/oav" -Recurse -Force `
+                  Get-ChildItem "$(Pipeline.Workspace)/drop" -Recurse -Force `
                     | Where-Object { $_.Name -like "*.tgz" } `
                     | Copy-Item -Destination "$(Build.ArtifactStagingDirectory)"
 

--- a/azure-pipelines/release-stage.yml
+++ b/azure-pipelines/release-stage.yml
@@ -38,3 +38,21 @@ stages:
 
                   Get-ChildItem "$(Build.ArtifactStagingDirectory)" -Recurse -Force | % { Write-Host $_.FullName }
                 displayName: Move artifact to $(Build.ArtifactStagingDirectory)
+
+              - task: EsrpRelease@7
+                inputs:
+                  displayName: 'Publish to ESRP'
+                  ConnectedServiceName: 'Azure SDK Engineering System'
+                  ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+                  KeyVaultName: 'AzureSDKEngKeyVault'
+                  AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+                  SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+                  Intent: 'PackageDistribution'
+                  ContentType: 'npm'
+                  FolderLocation: $(Build.ArtifactStagingDirectory)
+                  Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                  Approvers: 'azuresdk@microsoft.com'
+                  ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                  MainPublisher: 'ESRPRELPACMANTEST'
+                  DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+                  productstate: ${{ parameters.Version }}

--- a/azure-pipelines/staging-release-pipelines.yml
+++ b/azure-pipelines/staging-release-pipelines.yml
@@ -2,7 +2,7 @@ extends:
   template: /azure-pipelines/1es-redirect.yml
   parameters:  
     stages:
-    - stage: Staging_Release
+    - stage: Build
       displayName: Staging Release
 
       variables:
@@ -39,3 +39,8 @@ extends:
             parameters:
               ArtifactName: drop
               ArtifactPath: $(Build.SourcesDirectory)/dist
+
+    - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
+      - template: /.azure-pipelines/release-stage.yml
+        parameters:
+          Version: staging

--- a/azure-pipelines/staging-release-pipelines.yml
+++ b/azure-pipelines/staging-release-pipelines.yml
@@ -43,4 +43,4 @@ extends:
     - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
       - template: /.azure-pipelines/release-stage.yml
         parameters:
-          Version: staging
+          Version: beta

--- a/azure-pipelines/staging-release-pipelines.yml
+++ b/azure-pipelines/staging-release-pipelines.yml
@@ -41,6 +41,6 @@ extends:
               ArtifactPath: $(Build.SourcesDirectory)/dist
 
     - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
-      - template: /.azure-pipelines/release-stage.yml
+      - template: /azure-pipelines/release-stage.yml
         parameters:
           Version: beta


### PR DESCRIPTION
Hey openap-validator folks! This PR should only make your lives easier. I'm not changing anything other than adding a release stage to our build yml. The reason I'm doing this is because we going after the long-tail of builds that cannot be converted to `1es-templates`-compatible. The [staging](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=108) and [prod](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=80) releases to NPM for azure-openapi-validator need to be removed, but we also need to be certain you can still ship new versions of the package!

This PR will make it so that your [prod](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=1580) and [staging](https://dev.azure.com/azure-sdk/internal/_build/index?definitionId=5797) builds will also include approvable releases to npm.

In a nutshell, when you queue `Staging` or `Production` pipeline, you will immediately get an approvable release stage. Have to kick the pipeline manually to get the release stage.

![image](https://github.com/Azure/azure-openapi-validator/assets/45376673/0417be24-d589-4b79-98d9-b86a5c02bb10)

Prod stage will be labeled `release latest`. These are also the tags that are set on the ERSP release.

todo:

- [x] Re-use the ESRP config from azure-sdk-for-js
- [x] Repair failing sdl stage
- [x] Test a release
  -  [These are the artifacts published during a staging release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3837102&view=logs&j=50bf8411-d692-53a3-b519-144bb66a5252&t=fc5f6318-1b40-539a-791f-32c2a66051bb&l=15)
  - [These are the artifacts published during a prod release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3837139&view=results)
- [x] Clean up existing releases

Submitting this PR early to understand which CI will actually trigger.

Can one of the openapivalidator devs please confirm the two sets of artifacts on each linked release under the `Test a release` checkbox? Would I break anyone if I actually released a new version of the package?
