### PR TITLE
[AvoidAdditionalProperties] Set resolved:false to only report errors at the source

### DIFF
--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3159,7 +3159,7 @@ const ruleset = {
             message: "{{description}}",
             disableForTypeSpec: true,
             disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/no-record' rule.",
-            resolved: true,
+            resolved: false,
             formats: [oas2],
             given: "$.definitions..[?(@property !== 'tags' && @property !== 'delegatedResources' && @property !== 'userAssignedIdentities' && @ && @.additionalProperties)]",
             then: {

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -299,7 +299,8 @@ const ruleset: any = {
       message: "{{description}}",
       disableForTypeSpec: true,
       disableForTypeSpecReason: "Covered by TSP's '@azure-tools/typespec-azure-resource-manager/no-record' rule.",
-      resolved: true,
+      // Only report errors at the source, not from inside $refs (the resolved document)
+      resolved: false,
       formats: [oas2],
       // In some cases, variable "@" will be "null" when evaluating the expression, so it must be checked before dereferencing
       given:

--- a/packages/rulesets/src/spectral/test/avoid-additional-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/avoid-additional-properties.test.ts
@@ -144,7 +144,7 @@ test("AvoidAdditionalProperties should find errors", () => {
         required: ["type"],
       },
       ThisRef: {
-        description: "Ensure error is NOT raised from inside $refs (rule sets resolved:false)"
+        description: "Ensure error is NOT raised from inside $refs (rule sets resolved:false)",
         properties: {
           $ref: "#/definitions/This",
         },

--- a/packages/rulesets/src/spectral/test/avoid-additional-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/avoid-additional-properties.test.ts
@@ -144,6 +144,7 @@ test("AvoidAdditionalProperties should find errors", () => {
         required: ["type"],
       },
       ThisRef: {
+        description: "Ensure error is NOT raised from inside $refs (rule sets resolved:false)"
         properties: {
           $ref: "#/definitions/This",
         },
@@ -151,21 +152,19 @@ test("AvoidAdditionalProperties should find errors", () => {
     },
   }
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(7)
+    expect(results.length).toBe(6)
     expect(results[0].path.join(".")).toBe("definitions.This")
     expect(results[1].path.join(".")).toBe("definitions.That.properties.nonTags")
     expect(results[2].path.join(".")).toBe("definitions.ThaOther.properties")
     expect(results[3].path.join(".")).toBe("definitions.Other.properties")
     expect(results[4].path.join(".")).toBe("definitions.ThisOther.properties.tags.nonTags")
     expect(results[5].path.join(".")).toBe("definitions.UserAssignedIdentitiy")
-    expect(results[6].path.join(".")).toBe("definitions.ThisRef.properties")
     expect(results[0].message).toBe(errorMessage)
     expect(results[1].message).toBe(errorMessage)
     expect(results[2].message).toBe(errorMessage)
     expect(results[3].message).toBe(errorMessage)
     expect(results[4].message).toBe(errorMessage)
     expect(results[5].message).toBe(errorMessage)
-    expect(results[6].message).toBe(errorMessage)
   })
 })
 

--- a/packages/rulesets/src/spectral/test/avoid-additional-properties.test.ts
+++ b/packages/rulesets/src/spectral/test/avoid-additional-properties.test.ts
@@ -143,22 +143,29 @@ test("AvoidAdditionalProperties should find errors", () => {
         },
         required: ["type"],
       },
+      ThisRef: {
+        properties: {
+          $ref: "#/definitions/This",
+        },
+      },
     },
   }
   return linter.run(oasDoc).then((results) => {
-    expect(results.length).toBe(6)
+    expect(results.length).toBe(7)
     expect(results[0].path.join(".")).toBe("definitions.This")
     expect(results[1].path.join(".")).toBe("definitions.That.properties.nonTags")
     expect(results[2].path.join(".")).toBe("definitions.ThaOther.properties")
     expect(results[3].path.join(".")).toBe("definitions.Other.properties")
     expect(results[4].path.join(".")).toBe("definitions.ThisOther.properties.tags.nonTags")
     expect(results[5].path.join(".")).toBe("definitions.UserAssignedIdentitiy")
+    expect(results[6].path.join(".")).toBe("definitions.ThisRef.properties")
     expect(results[0].message).toBe(errorMessage)
     expect(results[1].message).toBe(errorMessage)
     expect(results[2].message).toBe(errorMessage)
     expect(results[3].message).toBe(errorMessage)
     expect(results[4].message).toBe(errorMessage)
     expect(results[5].message).toBe(errorMessage)
+    expect(results[6].message).toBe(errorMessage)
   })
 })
 


### PR DESCRIPTION
- Fixes #697

Verified it fixes the full spec in a local end-to-end test:

```
$ npx autorest --v3 --spectral --azure-validator --semantic-validator=false --model-validator=false \
  --openapi-type=arm --openapi-subtype=arm --use=@microsoft.azure/openapi-validator@2.2.2 \
  --tag=package-preview-2024-04 specification/desktopvirtualization/resource-manager/readme.md \
 | grep -i avoidadditionalproperties

error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
```

```
$ npx autorest --v3 --spectral --azure-validator --semantic-validator=false --model-validator=false \
  --openapi-type=arm --openapi-subtype=arm --use=./packages/azure-openapi-validator/autorest \
  --tag=package-preview-2024-04 ../specs/specification/desktopvirtualization/resource-manager/readme.md \
  | grep AvoidAdditionalProperties

error   | AvoidAdditionalProperties | Definitions must not have properties named additionalProperties except for user defined tags or predefined references.
```