### PR TITLE
Update guidance for tenant level APIs

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1216,9 +1216,7 @@ Please refer to [system-data-in-properties-bag.md](./system-data-in-properties-b
 
 ### TenantLevelAPIsNotAllowed
 
-Tenant level APIs are strongly discouraged and subscription or resource group level APIs are preferred instead.
-If you cannot model your APIs at these levels, you will need to present your design and get an exception from the PAS team.
-Once the exception is granted author would need to suppress the error being flagged by following steps mentioned in https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md#suppress-warnings
+Tenant level APIs are strongly discouraged and subscription or resource group level APIs are preferred instead. The reason for this guidance is that tenant level APIs have a really broad scope and blast radius. We permit APIs to be at this broad scope under rare conditions. Some ARM feature sets also do not cover tenant level APIs such as the use of AFEC. Additionally, if you intend to bypass the standard RBAC constructs and make the APIs unauthorized, you will need an approval from the PAS team before the open API spec can be merged.
 
 Please refer to [tenant-level-apis-not-allowed.md](./tenant-level-apis-not-allowed.md) for details.
 

--- a/docs/tenant-level-apis-not-allowed.md
+++ b/docs/tenant-level-apis-not-allowed.md
@@ -14,17 +14,19 @@ ARM OpenAPI(swagger) specs
 
 ## Description
 
-Tenant level APIs are strongly discouraged and subscription or resource group level APIs are preferred instead.
-If you cannot model your APIs at these levels, you will need to present your design and get an exception from the PAS team.
-
-Once the exception is granted author would need to suppress the error being flagged by following steps mentioned in https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md#suppress-warnings
+Tenant level APIs are strongly discouraged and subscription or resource group level APIs are preferred instead. The reason for this guidance is that tenant level APIs have a really broad scope and blast radius. We permit APIs to be at this broad scope under rare conditions. Some ARM feature sets also do not cover tenant level APIs such as the use of AFEC. Additionally, if you intend to bypass the standard RBAC constructs and make the APIs unauthorized, you will need an approval from the PAS team before the open API spec can be merged.
 
 ## How to fix the violation
 
-The error can be fixed by one of the following ways:
-1. Do not define tenant level api's for PUT operation
-1. If tenant level write operations cannot be avoided, get an exception from PAS team. Please reach out to the following contacts to do a design review - [SARBACRev], [prasnal@microsoft.com], (ARM Auth Team)[armrbac@microsoft.com]. Apply a suppression for this error providing an evidence of a sign-off to the API reviewer over email
+The error can be fixed in one of the following two ways
 
+1. Do not define tenant level APIs
+2.1. Provide a justification as to why you need the APIs to have the broad tenant scope to the ARM API reviewer. To do this, please attend the ARM API review office hours to have a conversation with the ARM API reviewer. To book a slot, please visit aka.ms\armofficehoursinfo.
+2.2 In addition to modeling the API at the tenant scope, if you also intend to add the API to the "allowUnauthorizedActions" list in your ARM manifest, you must present your design and get an exception from the PAS team. Once you get an approval, please share the evidence of the approval by dropping a screenshot of the written approval as a comment on the PR. Please proceed by adding a suppression for the linter error indicating that the exception has been approved by the PAS team. If you do not intend to add the API to the "allowUnauthorizedActions" list in your ARM manifest, please add a suppression indicating the same.
+
+Please use the following guidance to add a suppression - https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md#suppress-warnings
+
+To get an approval from PAS, please book their office hours slot at https://aka.ms/azurerbacofficehours . You will have to present the scenario and explain why the API needs to be unauthorized. If the service team would like to reach out over email, they can send an email to authzeng@microsoft.com 
 
 ## Good Examples
 

--- a/docs/tenant-level-apis-not-allowed.md
+++ b/docs/tenant-level-apis-not-allowed.md
@@ -21,8 +21,11 @@ Tenant level APIs are strongly discouraged and subscription or resource group le
 The error can be fixed in one of the following two ways
 
 1. Do not define tenant level APIs
-2.1. Provide a justification as to why you need the APIs to have the broad tenant scope to the ARM API reviewer. To do this, please attend the ARM API review office hours to have a conversation with the ARM API reviewer. To book a slot, please visit aka.ms\armofficehoursinfo.
-2.2 In addition to modeling the API at the tenant scope, if you also intend to add the API to the "allowUnauthorizedActions" list in your ARM manifest, you must present your design and get an exception from the PAS team. Once you get an approval, please share the evidence of the approval by dropping a screenshot of the written approval as a comment on the PR. Please proceed by adding a suppression for the linter error indicating that the exception has been approved by the PAS team. If you do not intend to add the API to the "allowUnauthorizedActions" list in your ARM manifest, please add a suppression indicating the same.
+2. Address both the sub sections below
+
+    1. Provide a justification as to why you need the APIs to have the broad tenant scope to the ARM API reviewer. To do this, please attend the ARM API review office hours to have a conversation with the ARM API reviewer. To book a slot, please visit aka.ms\armofficehoursinfo.
+
+    2. In addition to modeling the API at the tenant scope, if you also intend to add the API to the "allowUnauthorizedActions" list in your ARM manifest, you must present your design and get an exception from the PAS team. Once you get an approval, please share the evidence of the approval by dropping a screenshot of the written approval as a comment on the PR. Please proceed by adding a suppression for the linter error indicating that the exception has been approved by the PAS team. If you do not intend to add the API to the "allowUnauthorizedActions" list in your ARM manifest, please add a suppression indicating the same.
 
 Please use the following guidance to add a suppression - https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md#suppress-warnings
 


### PR DESCRIPTION
We got some clarifications from the PAS team on when they would like to be engaged to perform scenario reviews. This PR updates the guidance to the authors and reviewers on the same. 