### PR TITLE
Added a check if 202 response codes have response schema defined when it shouldnt

### DIFF
--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1509,7 +1509,7 @@ const SYNC_ERROR$2 = "Synchronous delete operations must have responses with 200
 const LR_ERROR$2 = "Long-running delete operations must have responses with 202, 204 and default return codes. They also must have no other response codes.";
 const EmptyResponse_ERROR$4 = "Delete operation response codes must be non-empty. It must have response codes 200, 204 and default if it is sync or 202, 204 and default if it is long running.";
 const DeleteResponseCodes = (deleteOp, _opts, ctx) => {
-    var _a;
+    var _a, _b;
     if (deleteOp === null || typeof deleteOp !== "object") {
         return [];
     }
@@ -1537,6 +1537,12 @@ const DeleteResponseCodes = (deleteOp, _opts, ctx) => {
         if (responses.length !== LR_DELETE_RESPONSES.length || !LR_DELETE_RESPONSES.every((value) => responses.includes(value))) {
             errors.push({
                 message: LR_ERROR$2,
+                path: path,
+            });
+        }
+        if ((_b = deleteOp.responses["202"]) === null || _b === void 0 ? void 0 : _b.schema) {
+            errors.push({
+                message: "202 response for a LRO DELETE operation must not have a response schema specified.",
                 path: path,
             });
         }
@@ -2124,7 +2130,7 @@ const SYNC_ERROR$1 = "Synchronous PATCH operations must have responses with 200 
 const LR_ERROR$1 = "Long-running PATCH operations must have responses with 200, 202 and default return codes. They also must not have other response codes.";
 const EmptyResponse_ERROR$2 = "PATCH operation response codes must be non-empty. It must have response codes 200 and default if it is sync or 200, 202 and default if it is long running.";
 const patchResponseCodes = (patchOp, _opts, ctx) => {
-    var _a;
+    var _a, _b;
     if (patchOp === null || typeof patchOp !== "object") {
         return [];
     }
@@ -2138,7 +2144,8 @@ const patchResponseCodes = (patchOp, _opts, ctx) => {
         });
         return errors;
     }
-    const isAsyncOperation = (patchOp["x-ms-long-running-operation"] && patchOp["x-ms-long-running-operation"] === true) || patchOp["x-ms-long-running-operation-options"];
+    const isAsyncOperation = (patchOp["x-ms-long-running-operation"] && patchOp["x-ms-long-running-operation"] === true) ||
+        patchOp["x-ms-long-running-operation-options"];
     if (isAsyncOperation) {
         if (!patchOp["x-ms-long-running-operation"] || patchOp["x-ms-long-running-operation"] !== true) {
             errors.push({
@@ -2150,6 +2157,12 @@ const patchResponseCodes = (patchOp, _opts, ctx) => {
         if (responses.length !== LR_PATCH_RESPONSES.length || !LR_PATCH_RESPONSES.every((value) => responses.includes(value))) {
             errors.push({
                 message: LR_ERROR$1,
+                path: path,
+            });
+        }
+        if ((_b = patchOp.responses["202"]) === null || _b === void 0 ? void 0 : _b.schema) {
+            errors.push({
+                message: "202 response for a LRO PATCH operation must not have a response schema specified.",
                 path: path,
             });
         }

--- a/packages/rulesets/src/spectral/functions/delete-response-codes.ts
+++ b/packages/rulesets/src/spectral/functions/delete-response-codes.ts
@@ -47,6 +47,13 @@ export const DeleteResponseCodes = (deleteOp: any, _opts: any, ctx: any) => {
         path: path,
       })
     }
+
+    if (deleteOp.responses["202"]?.schema) {
+      errors.push({
+        message: "202 response for a LRO DELETE operation must not have a response schema specified.",
+        path: path,
+      })
+    }
   } else {
     if (responses.length !== SYNC_DELETE_RESPONSES.length || !SYNC_DELETE_RESPONSES.every((value) => responses.includes(value))) {
       errors.push({

--- a/packages/rulesets/src/spectral/functions/patch-response-codes.ts
+++ b/packages/rulesets/src/spectral/functions/patch-response-codes.ts
@@ -9,7 +9,7 @@ const LR_ERROR =
   "Long-running PATCH operations must have responses with 200, 202 and default return codes. They also must not have other response codes."
 const EmptyResponse_ERROR =
   "PATCH operation response codes must be non-empty. It must have response codes 200 and default if it is sync or 200, 202 and default if it is long running."
-  
+
 export const patchResponseCodes = (patchOp: any, _opts: any, ctx: any) => {
   if (patchOp === null || typeof patchOp !== "object") {
     return []
@@ -27,7 +27,9 @@ export const patchResponseCodes = (patchOp: any, _opts: any, ctx: any) => {
     return errors
   }
 
-  const isAsyncOperation = (patchOp["x-ms-long-running-operation"] && patchOp["x-ms-long-running-operation"] === true) || patchOp["x-ms-long-running-operation-options"]
+  const isAsyncOperation =
+    (patchOp["x-ms-long-running-operation"] && patchOp["x-ms-long-running-operation"] === true) ||
+    patchOp["x-ms-long-running-operation-options"]
 
   if (isAsyncOperation) {
     if (!patchOp["x-ms-long-running-operation"] || patchOp["x-ms-long-running-operation"] !== true) {
@@ -41,6 +43,13 @@ export const patchResponseCodes = (patchOp: any, _opts: any, ctx: any) => {
     if (responses.length !== LR_PATCH_RESPONSES.length || !LR_PATCH_RESPONSES.every((value) => responses.includes(value))) {
       errors.push({
         message: LR_ERROR,
+        path: path,
+      })
+    }
+
+    if (patchOp.responses["202"]?.schema) {
+      errors.push({
+        message: "202 response for a LRO PATCH operation must not have a response schema specified.",
         path: path,
       })
     }

--- a/packages/rulesets/src/spectral/test/delete-response-codes.test.ts
+++ b/packages/rulesets/src/spectral/test/delete-response-codes.test.ts
@@ -5,6 +5,7 @@ const LR_ERROR =
   "Long-running delete operations must have responses with 202, 204 and default return codes. They also must have no other response codes."
 const SYNC_ERROR =
   "Synchronous delete operations must have responses with 200, 204 and default return codes. They also must have no other response codes."
+const RESPONSE_SCHEMA_202 = "202 response for a LRO DELETE operation must not have a response schema specified."
 
 let linter: Spectral
 
@@ -567,9 +568,11 @@ test("DeleteResponseCodes should find errors for lro delete with only 202", () =
     },
   }
   return linter.run(myOpenApiDocument).then((results) => {
-    expect(results.length).toBe(1)
+    expect(results.length).toBe(2)
     expect(results[0].path.join(".")).toBe("paths./foo.delete")
     expect(results[0].message).toContain(LR_ERROR)
+    expect(results[1].path.join(".")).toBe("paths./foo.delete")
+    expect(results[1].message).toContain(RESPONSE_SCHEMA_202)
   })
 })
 
@@ -663,9 +666,6 @@ test("DeleteResponseCodes should find errors for lro delete without default resp
           responses: {
             "202": {
               description: "accepted",
-              schema: {
-                $ref: "#/definitions/FooResource",
-              },
             },
             "204": {
               description: "No content",
@@ -738,9 +738,6 @@ test("DeleteResponseCodes should find errors for lro delete with extra response 
           responses: {
             "202": {
               description: "accepted",
-              schema: {
-                $ref: "#/definitions/FooResource",
-              },
             },
             "204": {
               description: "No content",
@@ -823,9 +820,6 @@ test("DeleteResponseCodes should find no errors for lro delete when all required
           responses: {
             "202": {
               description: "accepted",
-              schema: {
-                $ref: "#/definitions/FooResource",
-              },
             },
             "204": {
               description: "No content",
@@ -912,9 +906,6 @@ test("DeleteResponseCodes should find errors for async delete with 202 but no x-
             },
             "202": {
               description: "accepted",
-              schema: {
-                $ref: "#/definitions/FooResource",
-              },
             },
             default: {
               description: "Error",

--- a/packages/rulesets/src/spectral/test/patch-response-codes.test.ts
+++ b/packages/rulesets/src/spectral/test/patch-response-codes.test.ts
@@ -5,6 +5,7 @@ const SYNC_ERROR =
   "Synchronous PATCH operations must have responses with 200 and default return codes. They also must not have other response codes."
 const LR_ERROR =
   "Long-running PATCH operations must have responses with 200, 202 and default return codes. They also must not have other response codes."
+const RESPONSE_SCHEMA_202 = "202 response for a LRO PATCH operation must not have a response schema specified."
 
 let linter: Spectral
 
@@ -440,6 +441,9 @@ test("PatchResponseCodes should find errors for lro patch with only 202", () => 
           responses: {
             "202": {
               description: "accepted",
+              schema: {
+                $ref: "#/definitions/FooResource",
+              },
             },
           },
           "x-ms-long-running-operation": true,
@@ -479,9 +483,11 @@ test("PatchResponseCodes should find errors for lro patch with only 202", () => 
     },
   }
   return linter.run(myOpenApiDocument).then((results) => {
-    expect(results.length).toBe(1)
+    expect(results.length).toBe(2)
     expect(results[0].path.join(".")).toBe("paths./foo.patch")
     expect(results[0].message).toContain(LR_ERROR)
+    expect(results[1].path.join(".")).toBe("paths./foo.patch")
+    expect(results[1].message).toContain(RESPONSE_SCHEMA_202)
   })
 })
 


### PR DESCRIPTION
Added an if statement to make sure there should be no "schema" defined for 202 response codes for both PATCH and DELETE.
POST is already implemented, added similar if condition for both PATCH and DELETE

WI - https://msazure.visualstudio.com/One/_workitems/edit/28118100
