### PR TITLE
disable rule PatchPropertiesCorrespondToPutProperties 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,8 +390,7 @@ Once your PR is merged:
 
 - Schedule a [Prod build] from the `main` branch.
 - **!!! IMPORTANT !!!**: If you are updating [packages/azure-openapi-validator/autorest], see [this section](#synchronize-with-changes-to-openapi-alps-repository).
-- 
-  You may need to get an approval for the release from the appropriate [Azure SDK EngSys team members](https://teams.microsoft.com/l/channel/19%3A59dbfadafb5e41c4890e2cd3d74cc7ba%40thread.skype/Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121).
+- You may need to get an approval for the release from the appropriate [Azure SDK EngSys team members](https://teams.microsoft.com/l/channel/19%3A59dbfadafb5e41c4890e2cd3d74cc7ba%40thread.skype/Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121).
 - Verify the release worked by new versions of the appropriate packages being released to npm.
   See [README `packages` section]. You can also look at the release build log.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,10 +390,8 @@ Once your PR is merged:
 
 - Schedule a [Prod build] from the `main` branch.
 - **!!! IMPORTANT !!!**: If you are updating [packages/azure-openapi-validator/autorest], see [this section](#synchronize-with-changes-to-openapi-alps-repository).
-- Once the build is complete, schedule a [Prod npm release] from that build.
-  You may need to get an approval for the release from the appropriate Azure SDK EngSys team members.
-- Note that sometimes the npm release may report failure even when it succeeded. This is because sometimes it tries to
-  publish package twice and succeeds only on the first try.
+- 
+  You may need to get an approval for the release from the appropriate [Azure SDK EngSys team members](https://teams.microsoft.com/l/channel/19%3A59dbfadafb5e41c4890e2cd3d74cc7ba%40thread.skype/Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121).
 - Verify the release worked by new versions of the appropriate packages being released to npm.
   See [README `packages` section]. You can also look at the release build log.
 

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3458,6 +3458,7 @@ const ruleset = {
             description: "PATCH request body must only contain properties present in the corresponding PUT request body, and must contain at least one property.",
             message: "{{error}}",
             severity: "error",
+            stagingOnly: true,
             resolved: true,
             formats: [oas2],
             given: ["$[paths,'x-ms-paths'].*"],

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -459,6 +459,7 @@ const ruleset: any = {
         "PATCH request body must only contain properties present in the corresponding PUT request body, and must contain at least one property.",
       message: "{{error}}",
       severity: "error",
+      stagingOnly: true,
       resolved: true,
       formats: [oas2],
       given: ["$[paths,'x-ms-paths'].*"],


### PR DESCRIPTION
Set back PatchPropertiesCorrespondToPutProperties to staging and update the PROD release pipeline guidelines