### PR TITLE
Add new rule ValidQueryParametersForPointOperations

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1244,7 +1244,7 @@ Per [ARM guidelines](https://github.com/Azure/azure-resource-manager-rpc/blob/ma
 
 Please refer to [top-level-resources-list-by-subscription.md](./top-level-resources-list-by-subscription.md) for details.
 
-### trackedExtensionResourcesAreNotAllowed
+### TrackedExtensionResourcesAreNotAllowed
 
 Extension resources are always considered to be proxy and must not be of the type tracked.
 
@@ -1343,6 +1343,12 @@ Please refer to [unique-xms-example.md](./unique-xms-example.md) for details.
 Only valid types are allowed for properties.
 
 Please refer to [valid-formats.md](./valid-formats.md) for details.
+
+### ValidQueryParametersForPointOperations
+
+Point operations (GET, PUT, PATCH, DELETE) must not include any query parameters other than api-version.
+
+Please refer to [valid-query-parameters-for-point-operations.md](./valid-query-parameters-for-point-operations.md) for details.
 
 ### ValidResponseCodeRequired
 

--- a/docs/tracked-extension-resources-are-not-allowed.md
+++ b/docs/tracked-extension-resources-are-not-allowed.md
@@ -1,4 +1,4 @@
-# trackedExtensionResourcesAreNotAllowed
+# TrackedExtensionResourcesAreNotAllowed
 
 ## Category
 

--- a/docs/valid-query-parameters-for-point-operations.md
+++ b/docs/valid-query-parameters-for-point-operations.md
@@ -1,0 +1,107 @@
+# ValidQueryParametersForPointOperations
+
+## Category
+
+ARM Error
+
+## Applies to
+
+ARM OpenAPI(swagger) specs
+
+## Related ARM Guideline Code
+
+- RPC-Uri-V1-13
+
+## Description
+
+Point operations (GET, PUT, PATCH, DELETE) must not include any query parameters other than api-version.
+
+## How to fix the violation
+
+Remove all query params other than api-version for point operations (GET, PUT, PATCH, DELETE).
+
+## Good Examples
+
+```json
+    "Microsoft.Music/Songs": {
+      "get": {
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query"
+          },
+        ],
+      },
+      "put": {
+        "operationId": "Foo_Update",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query"
+          },
+        ],
+      },
+      "patch": {
+        "operationId": "Foo_Update",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query"
+          },
+        ],
+      },
+      "delete": {
+        "operationId": "Foo_Update",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query"
+          },
+        ],
+      },
+    },
+```
+
+## Bad Examples
+
+```json
+    "Microsoft.Music/Songs": {
+      "get": {
+        "operationId": "Foo_get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "type": "string",
+          },
+        ],
+      },
+      "put": {
+        "operationId": "Foo_Create",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "$filter",
+            "in": "query"
+          },
+        ],
+      },
+      "patch": {
+        "operationId": "Foo_Update",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query"
+          },
+        ],
+      },
+    },
+```

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -385,6 +385,18 @@ const providerAndNamespace = "/providers/[^/]+";
 const resourceTypeAndResourceName = "(?:/\\w+/default|/\\w+/{[^/]+})";
 const queryParam = "(?:\\?\\w+)";
 const resourcePathRegEx = new RegExp(`${providerAndNamespace}${resourceTypeAndResourceName}+${queryParam}?$`, "gi");
+function isPointOperation(path) {
+    const index = path.lastIndexOf("/providers/");
+    if (index === -1) {
+        return false;
+    }
+    const lastProvider = path.substr(index);
+    const matches = lastProvider.match(resourcePathRegEx);
+    if (matches) {
+        return true;
+    }
+    return false;
+}
 function getResourcesPathHierarchyBasedOnResourceType(path) {
     const index = path.lastIndexOf("/providers/");
     if (index === -1) {
@@ -2846,6 +2858,37 @@ const trackedResourceTagsPropertyInRequest = (pathItem, _opts, paths) => {
     return errors;
 };
 
+const validQueryParametersForPointOperations = (pathItem, _opts, ctx) => {
+    if (pathItem === null || typeof pathItem !== "object") {
+        return [];
+    }
+    const path = ctx.path || [];
+    const uris = Object.keys(pathItem);
+    if (uris.length < 1) {
+        return [];
+    }
+    const pointOperations = new Set(["get", "put", "patch", "delete"]);
+    const errors = [];
+    for (const uri of uris) {
+        if (isPointOperation(uri)) {
+            const verbs = Object.keys(pathItem[uri]);
+            for (const verb of verbs) {
+                if (pointOperations.has(verb)) {
+                    const params = pathItem[uri][verb]["parameters"];
+                    const queryParams = params === null || params === void 0 ? void 0 : params.filter((param) => param.in === "query" && param.name !== "api-version");
+                    queryParams === null || queryParams === void 0 ? void 0 : queryParams.map((param) => {
+                        errors.push({
+                            message: `Query parameter ${param.name} should be removed. Point operation '${verb}' MUST not have query parameters other than api-version.`,
+                            path: [path, uri, verb, "parameters"],
+                        });
+                    });
+                }
+            }
+        }
+    }
+    return errors;
+};
+
 const validatePatchBodyParamProperties = createRulesetFunction({
     input: null,
     options: {
@@ -3876,6 +3919,19 @@ const ruleset = {
             given: "$[paths,'x-ms-paths'].*~",
             then: {
                 function: trackedExtensionResourcesAreNotAllowed,
+            },
+        },
+        ValidQueryParametersForPointOperations: {
+            rpcGuidelineCode: "RPC-Uri-V1-13",
+            description: "Point operations (GET, PUT, PATCH, DELETE) must not include any query parameters other than api-version.",
+            message: "{{error}}",
+            stagingOnly: true,
+            severity: "error",
+            resolved: true,
+            formats: [oas2],
+            given: "$[paths,'x-ms-paths']",
+            then: {
+                function: validQueryParametersForPointOperations,
             },
         },
         SystemDataDefinitionsCommonTypes: {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -51,6 +51,7 @@ import { tagsAreNotAllowedForProxyResources } from "./functions/tags-are-not-all
 import { tenantLevelAPIsNotAllowed } from "./functions/tenant-level-apis-not-allowed"
 import { trackedExtensionResourcesAreNotAllowed } from "./functions/tracked-extension-resources-are-not-allowed"
 import trackedResourceTagsPropertyInRequest from "./functions/trackedresource-tags-property-in-request"
+import { validQueryParametersForPointOperations } from "./functions/valid-query-parameters-for-point-operations"
 import { validatePatchBodyParamProperties } from "./functions/validate-patch-body-param-properties"
 import withXmsResource from "./functions/with-xms-resource"
 import verifyXMSLongRunningOperationProperty from "./functions/xms-long-running-operation-property"
@@ -941,6 +942,20 @@ const ruleset: any = {
       given: "$[paths,'x-ms-paths'].*~",
       then: {
         function: trackedExtensionResourcesAreNotAllowed,
+      },
+    },
+    // RPC Code: RPC-Uri-V1-13
+    ValidQueryParametersForPointOperations: {
+      rpcGuidelineCode: "RPC-Uri-V1-13",
+      description: "Point operations (GET, PUT, PATCH, DELETE) must not include any query parameters other than api-version.",
+      message: "{{error}}",
+      stagingOnly: true,
+      severity: "error",
+      resolved: true,
+      formats: [oas2],
+      given: "$[paths,'x-ms-paths']",
+      then: {
+        function: validQueryParametersForPointOperations,
       },
     },
 

--- a/packages/rulesets/src/spectral/functions/utils.ts
+++ b/packages/rulesets/src/spectral/functions/utils.ts
@@ -242,6 +242,25 @@ const providerAndNamespace = "/providers/[^/]+"
 const resourceTypeAndResourceName = "(?:/\\w+/default|/\\w+/{[^/]+})"
 const queryParam = "(?:\\?\\w+)"
 const resourcePathRegEx = new RegExp(`${providerAndNamespace}${resourceTypeAndResourceName}+${queryParam}?$`, "gi")
+/**
+ * Checks if the provided path is a point operation 
+ * i.e, if its a path that can have point GET, PUT, PATCH, DELETE
+ * @param path path/uri
+ * @returns true or false 
+ */
+export function isPointOperation(path: string) {
+  const index = path.lastIndexOf("/providers/")
+  if (index === -1) {
+    return false
+  }
+  const lastProvider = path.substr(index)
+  const matches = lastProvider.match(resourcePathRegEx)
+  if(matches){
+    return true
+  }
+  return false
+}
+
 export function getResourcesPathHierarchyBasedOnResourceType(path: string) {
   const index = path.lastIndexOf("/providers/")
   if (index === -1) {

--- a/packages/rulesets/src/spectral/functions/valid-query-parameters-for-point-operations.ts
+++ b/packages/rulesets/src/spectral/functions/valid-query-parameters-for-point-operations.ts
@@ -1,0 +1,37 @@
+import { isPointOperation } from "./utils"
+
+export const validQueryParametersForPointOperations = (pathItem: any, _opts: any, ctx: any) => {
+  if (pathItem === null || typeof pathItem !== "object") {
+    return []
+  }
+
+  const path = ctx.path || []
+  const uris = Object.keys(pathItem)
+  if (uris.length < 1) {
+    return []
+  }
+  const pointOperations = new Set(["get", "put", "patch", "delete"])
+  const errors: any[] = []
+
+  for (const uri of uris) {
+    //check if the path is a point operation 
+    if (isPointOperation(uri)) {
+      const verbs = Object.keys(pathItem[uri])
+      for (const verb of verbs) {
+        //check query params only for point operations/verbs
+        if (pointOperations.has(verb)) {
+          const params = pathItem[uri][verb]["parameters"]
+          const queryParams = params?.filter((param: { in: string; name: string }) => param.in === "query" && param.name !== "api-version")
+          queryParams?.map((param: { name: any }) => {
+            errors.push({
+              message: `Query parameter ${param.name} should be removed. Point operation '${verb}' MUST not have query parameters other than api-version.`,
+              path: [path, uri, verb, "parameters"],
+            })
+          })
+        }
+      }
+    }
+  }
+
+  return errors
+}

--- a/packages/rulesets/src/spectral/test/latest-version-of-common-types-must-be-used.test.ts
+++ b/packages/rulesets/src/spectral/test/latest-version-of-common-types-must-be-used.test.ts
@@ -116,7 +116,7 @@ test("LatestVersionOfCommonTypesMustBeUsed should find no errors", async () => {
     expect(results.length).toBe(0)
   })
 })
-test("ParametersInPointGet should find no errors when common-types ref is not present", async () => {
+test("LatestVersionOfCommonTypesMustBeUsed should find no errors when common-types ref is not present", async () => {
   const myOpenApiDocument = {
     swagger: "2.0",
     paths: {

--- a/packages/rulesets/src/spectral/test/valid-query-parameters-for-point-operations.test.ts
+++ b/packages/rulesets/src/spectral/test/valid-query-parameters-for-point-operations.test.ts
@@ -1,0 +1,372 @@
+import { Spectral } from "@stoplight/spectral-core"
+import linterForRule from "./utils"
+
+let linter: Spectral
+
+beforeAll(async () => {
+  linter = await linterForRule("ValidQueryParametersForPointOperations")
+  return linter
+})
+
+test("ValidQueryParametersForPointOperations should find errors for top level path", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}": {
+        get: {
+          operationId: "foo_get",
+          parameters: [
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+        delete: {
+          operationId: "foo_delete",
+          parameters: [
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+      },
+      "/providers/Microsoft.Music/Albums/{Great}": {
+        get: {
+          operationId: "foo_get",
+          parameters: [
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+        put: {
+          operationId: "foo_put",
+          parameters: [
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(4)
+    expect(results[0].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}.get.parameters")
+    expect(results[0].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+    expect(results[1].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}.delete.parameters")
+    expect(results[1].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'delete' MUST not have query parameters other than api-version.",
+    )
+    expect(results[2].path.join(".")).toBe("paths./providers/Microsoft.Music/Albums/{Great}.get.parameters")
+    expect(results[2].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+    expect(results[3].path.join(".")).toBe("paths./providers/Microsoft.Music/Albums/{Great}.put.parameters")
+    expect(results[3].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'put' MUST not have query parameters other than api-version.",
+    )
+  })
+})
+
+test("ValidQueryParametersForPointOperations should find errors for nested path", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}": {
+        get: {
+          operationId: "foo_get",
+          parameters: [
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+        put: {
+          operationId: "foo_put",
+          parameters: [
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(2)
+    expect(results[0].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}.get.parameters")
+    expect(results[0].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+    expect(results[1].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}.put.parameters")
+    expect(results[1].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'put' MUST not have query parameters other than api-version.",
+    )
+  })
+})
+
+test("ValidQueryParametersForPointOperations should find errors for more than one query param", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}": {
+        get: {
+          operationId: "foo_get",
+          parameters: [
+            {
+              $ref: "#/parameters/LoadTestNameParameter",
+            },
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      LoadTestNameParameter: {
+        in: "query",
+        name: "loadTestName",
+        description: "Load Test name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(2)
+    expect(results[0].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}.get.parameters")
+    expect(results[0].message).toContain(
+      "Query parameter loadTestName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+    expect(results[1].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}.get.parameters")
+    expect(results[1].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+  })
+})
+
+test("ValidQueryParametersForPointOperations should flag error for other query params but should not flag error for api-version param", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}": {
+        get: {
+          operationId: "foo_post",
+          parameters: [
+            {
+              $ref: "src/spectral/test/resources/types.json#/parameters/ApiVersionParameter",
+            },
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(1)
+    expect(results[0].path.join(".")).toBe("paths./providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}.get.parameters")
+    expect(results[0].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+  })
+})
+
+test("ValidQueryParametersForPointOperations should find no errors when query parameters are not present", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}": {
+        put: {
+          operationId: "foo_post",
+          parameters: [
+            {
+              $ref: "src/spectral/test/resources/types.json#/parameters/ResourceGroupNameParameter",
+            },
+            {
+              $ref: "#/parameters/LoadTestNameParameter",
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+      },
+    },
+    parameters: {
+      LoadTestNameParameter: {
+        in: "path",
+        name: "loadTestName",
+        description: "Load Test name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("ValidQueryParametersForPointOperations should find no errors for a list operation", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs": {
+        get: {
+          operationId: "foo_post",
+          parameters: [
+            {
+              $ref: "src/spectral/test/resources/types.json#/parameters/ResourceGroupNameParameter",
+            },
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+      },
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist": {
+        get: {
+          operationId: "foo_post",
+          parameters: [
+            {
+              $ref: "src/spectral/test/resources/types.json#/parameters/ResourceGroupNameParameter",
+            },
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+      },
+    },
+    parameters: {
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("ValidQueryParametersForPointOperations should find errors for x-ms-paths", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    "x-ms-paths": {
+      "/providers/Microsoft.Music/songs/{unstoppable}?disambiguation_dummy": {
+        get: {
+          operationId: "foo_post",
+          parameters: [
+            {
+              $ref: "src/spectral/test/resources/types.json#/parameters/SubscriptionIdParameter",
+            },
+            {
+              $ref: "#/parameters/QuotaBucketNameParameter",
+            },
+          ],
+        },
+      },
+    },
+    parameters: {
+      QuotaBucketNameParameter: {
+        in: "query",
+        name: "quotaBucketName",
+        description: "Quota Bucket name.",
+        required: true,
+        "x-ms-parameter-location": "method",
+        type: "string",
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(1)
+    expect(results[0].path.join(".")).toBe("x-ms-paths./providers/Microsoft.Music/songs/{unstoppable}?disambiguation_dummy.get.parameters")
+    expect(results[0].message).toContain(
+      "Query parameter quotaBucketName should be removed. Point operation 'get' MUST not have query parameters other than api-version.",
+    )
+  })
+})
+
+test("ValidQueryParametersForPointOperations should find no errors if parameters is not defined", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/providers/Microsoft.Music/songs/{unstoppable}/artist/{sia}": {
+        get: {
+          operationId: "foo_post",
+          responses: {
+            200: {
+              description: "Success",
+            },
+          },
+        },
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR adds new linter rule - ValidQueryParametersForPointOperations
to validate "Point operations (GET, PUT, PATCH, DELETE) do not include any query parameters other than api-version"