### PR TITLE
Added new rule LroAzureAsyncOperationHeader

### DIFF
--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -1,0 +1,67 @@
+# LroAzureAsyncOperationHeader
+
+## Category
+
+ARM Error
+
+## Applies to
+
+ARM OpenAPI(swagger) specs
+
+## Related ARM Guideline Code
+
+- RPC-Async-V1-06
+
+## Output Message
+
+A 202 response should include an Azure-AsyncOperation response header.
+
+## Description
+
+Azure-AsyncOperation header must be supported for all async operations that return 202.
+
+## CreatedAt
+
+Oct 11, 2024
+
+## How to fix the violation
+
+Adding the Azure-AsyncOperation header schema to the 202 response header schema.
+
+## Good Example
+
+```json
+  "/api/configServers": {
+    put: {
+      operationId: "ConfigServers_Update",
+      responses: {
+        202: {
+          description: 'Accepted',
+          headers: {
+            'Azure-AsyncOperation': {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+```
+
+## Bad Example
+
+```json
+  "/api/configServers": {
+    put: {
+      operationId: "ConfigServers_Update",
+      responses: {
+        "202": {
+          description: "Success",
+          headers: {
+            //No Azure-AsyncOperation header 
+          },
+        },
+      },
+    },
+  },
+```

--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -14,11 +14,12 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-All long-running operations must include an Azure-AsyncOperation response header.
+All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header.
 
 ## Description
 
-Azure-AsyncOperation header must be supported for all async long-running operations.
+If the headers field is present, the `Azure-AsyncOperation' header must be included in the response headers for
+all asynchronous long-running operations.
 
 ## CreatedAt
 

--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -14,12 +14,17 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header.
+All long-running operations must include an `Azure-AsyncOperation' response header.
 
 ## Description
 
-If the headers field is present, the `Azure-AsyncOperation' header must be included in the response headers for
-all asynchronous long-running operations.
+ARM relies on the async operation header to poll for the status of the long running operation. Based on this and the
+final state of the operation, downstream services like ARN and ARG are notified of the current state of the operation
+and the status of the resource. If you are a brownfield service that does not implement this header, you may add a
+suppression using the following TSG indicating the same.
+TSG link - https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md.
+In the description for the suppression, please provide a rough timeline by which the header will be supported by your
+service. More details about this header can be found in the ARM Resource Provider Contract documentation here - https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/async-api-reference.md#azure-asyncoperation-resource-format
 
 ## CreatedAt
 

--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -32,7 +32,7 @@ Oct 11, 2024
 
 ## How to fix the violation
 
-Adding the Azure-AsyncOperation header to the response..
+Adding the Azure-AsyncOperation header to the response.
 
 ## Good Example
 

--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -54,7 +54,7 @@ Adding the Azure-AsyncOperation header to the response.
   },
 ```
 
-## Bad Example
+## Bad Example 1
 
 ```json
   "/api/configServers": {
@@ -71,3 +71,18 @@ Adding the Azure-AsyncOperation header to the response.
     },
   },
 ```
+
+## Bad Example 2
+
+```json
+  "/api/configServers": {
+    "put": {
+      "operationId": "ConfigServers_Update",
+      "responses": {
+        "202": {
+          "description": "Success",
+          //No headers
+        },
+      },
+    },
+  },

--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -14,11 +14,11 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-A 202 response should include an Azure-AsyncOperation response header.
+All long-running operations must include an Azure-AsyncOperation response header.
 
 ## Description
 
-Azure-AsyncOperation header must be supported for all async operations that return 202.
+Azure-AsyncOperation header must be supported for all async long-running operations.
 
 ## CreatedAt
 
@@ -26,20 +26,20 @@ Oct 11, 2024
 
 ## How to fix the violation
 
-Adding the Azure-AsyncOperation header schema to the 202 response header schema.
+Adding the Azure-AsyncOperation header to the response..
 
 ## Good Example
 
 ```json
   "/api/configServers": {
-    put: {
-      operationId: "ConfigServers_Update",
-      responses: {
-        202: {
-          description: 'Accepted',
-          headers: {
-            'Azure-AsyncOperation': {
-              type: 'string',
+    "put": {
+      "operationId": "ConfigServers_Update",
+      "responses": {
+        "202": {
+          "description": "Accepted",
+          "headers": {
+            "Azure-AsyncOperation": {
+              "type": "string",
             },
           },
         },
@@ -52,12 +52,12 @@ Adding the Azure-AsyncOperation header schema to the 202 response header schema.
 
 ```json
   "/api/configServers": {
-    put: {
-      operationId: "ConfigServers_Update",
-      responses: {
+    "put": {
+      "operationId": "ConfigServers_Update",
+      "responses": {
         "202": {
-          description: "Success",
-          headers: {
+          "description": "Success",
+          "headers": {
             //No Azure-AsyncOperation header 
           },
         },

--- a/docs/lro-azure-async-operation-header.md
+++ b/docs/lro-azure-async-operation-header.md
@@ -14,7 +14,7 @@ ARM OpenAPI(swagger) specs
 
 ## Output Message
 
-All long-running operations must include an `Azure-AsyncOperation' response header.
+All long-running operations must include an `Azure-AsyncOperation` response header.
 
 ## Description
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -497,7 +497,8 @@ Please refer to [long-running-response-status-code-data-plane.md](./long-running
 
 ### LroAzureAsyncOperationHeader
 
-Azure-AsyncOperation header must be supported for all async long-running operations.
+If the headers field is present, the `Azure-AsyncOperation' header must be included in the response headers for
+all asynchronous long-running operations.
 
 Please refer to [lro-azure-async-operation-header.md](./lro-azure-async-operation-header.md) for details.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -497,8 +497,13 @@ Please refer to [long-running-response-status-code-data-plane.md](./long-running
 
 ### LroAzureAsyncOperationHeader
 
-If the headers field is present, the `Azure-AsyncOperation' header must be included in the response headers for
-all asynchronous long-running operations.
+ARM relies on the async operation header to poll for the status of the long running operation. Based on this and the
+final state of the operation, downstream services like ARN and ARG are notified of the current state of the operation
+and the status of the resource. If you are a brownfield service that does not implement this header, you may add a
+suppression using the following TSG indicating the same.
+TSG link - https://github.com/Azure/autorest/blob/main/docs/generate/suppress-warnings.md.
+In the description for the suppression, please provide a rough timeline by which the header will be supported by your
+service. More details about this header can be found in the ARM Resource Provider Contract documentation here - https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/async-api-reference.md#azure-asyncoperation-resource-format
 
 Please refer to [lro-azure-async-operation-header.md](./lro-azure-async-operation-header.md) for details.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -495,6 +495,12 @@ For Data plane spec, the allowed response status codes for a long DELETE operati
 
 Please refer to [long-running-response-status-code-data-plane.md](./long-running-response-status-code-data-plane.md) for details.
 
+### LroAzureAsyncOperationHeader
+
+Azure-AsyncOperation header must be supported for all async operations that return 202.
+
+Please refer to [lro-azure-async-operation-header.md](./lro-azure-async-operation-header.md) for details.
+
 ### LroErrorContent
 
 Error response content of long running operations must follow the error schema provided in the common types v2 and above.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -497,7 +497,7 @@ Please refer to [long-running-response-status-code-data-plane.md](./long-running
 
 ### LroAzureAsyncOperationHeader
 
-Azure-AsyncOperation header must be supported for all async operations that return 202.
+Azure-AsyncOperation header must be supported for all async long-running operations.
 
 Please refer to [lro-azure-async-operation-header.md](./lro-azure-async-operation-header.md) for details.
 

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1744,15 +1744,13 @@ const locationMustHaveXmsMutability = (scheme, _opts, paths) => {
 };
 
 const lroAzureAsyncOperationHeader = (headers, _opts, ctx) => {
-    if (headers) {
-        if (headers === null || !Object.keys(headers).includes("Azure-AsyncOperation")) {
-            return [
-                {
-                    message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
-                    path: ctx.path,
-                },
-            ];
-        }
+    if (!Object.keys(headers).includes("headers") || !Object.keys(headers.headers).includes("Azure-AsyncOperation")) {
+        return [
+            {
+                message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+                path: ctx.path.concat("headers"),
+            },
+        ];
     }
     return [];
 };
@@ -3331,12 +3329,9 @@ const ruleset = {
             message: "{{description}}",
             severity: "error",
             formats: [oas2],
-            given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers"],
+            given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*"],
             then: {
                 function: lroAzureAsyncOperationHeader,
-                functionOptions: {
-                    name: "Azure-AsyncOperation",
-                },
             },
         },
         LroLocationHeader: {

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3313,13 +3313,16 @@ const ruleset = {
         },
         LroAzureAsyncOperationHeader: {
             rpcGuidelineCode: "RPC-Async-V1-06",
-            description: "All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header.",
+            description: "All long-running operations must include an `Azure-AsyncOperation' response header.",
             message: "{{description}}",
             severity: "error",
             formats: [oas2],
-            given: "$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers[?(@property !== 'Azure-AsyncOperation')]",
+            given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*"],
             then: {
-                function: falsy,
+                function: hasHeader,
+                functionOptions: {
+                    name: "Azure-AsyncOperation",
+                },
             },
         },
         LroLocationHeader: {

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1743,6 +1743,20 @@ const locationMustHaveXmsMutability = (scheme, _opts, paths) => {
         }];
 };
 
+const lroAzureAsyncOperationHeader = (headers, _opts, ctx) => {
+    if (headers) {
+        if (headers === null || !Object.keys(headers).includes("Azure-AsyncOperation")) {
+            return [
+                {
+                    message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+                    path: ctx.path,
+                },
+            ];
+        }
+    }
+    return [];
+};
+
 const validateOriginalUri = (lroOptions, opts, ctx) => {
     if (!lroOptions || typeof lroOptions !== "object") {
         return [];
@@ -3317,9 +3331,9 @@ const ruleset = {
             message: "{{description}}",
             severity: "error",
             formats: [oas2],
-            given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*"],
+            given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers"],
             then: {
-                function: hasHeader,
+                function: lroAzureAsyncOperationHeader,
                 functionOptions: {
                     name: "Azure-AsyncOperation",
                 },

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3301,6 +3301,20 @@ const ruleset = {
                 function: provisioningState,
             },
         },
+        LroAzureAsyncOperationHeader: {
+            rpcGuidelineCode: "RPC-Async-V1-06",
+            description: "Azure-AsyncOperation header must be supported for all async operations that return 202.",
+            message: "{{description}}",
+            severity: "error",
+            formats: [oas2],
+            given: "$.paths[*][*].responses[?(@property == '202')]",
+            then: {
+                function: hasHeader,
+                functionOptions: {
+                    name: "Azure-AsyncOperation",
+                },
+            },
+        },
         LroLocationHeader: {
             rpcGuidelineCode: "RPC-Async-V1-07",
             description: "Location header must be supported for all async operations that return 202.",

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -1747,7 +1747,7 @@ const lroAzureAsyncOperationHeader = (headers, _opts, ctx) => {
     if (!Object.keys(headers).includes("headers") || !Object.keys(headers.headers).includes("Azure-AsyncOperation")) {
         return [
             {
-                message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+                message: "All long-running operations must include an `Azure-AsyncOperation` response header.",
                 path: ctx.path.concat("headers"),
             },
         ];
@@ -3325,7 +3325,7 @@ const ruleset = {
         },
         LroAzureAsyncOperationHeader: {
             rpcGuidelineCode: "RPC-Async-V1-06",
-            description: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+            description: "All long-running operations must include an `Azure-AsyncOperation` response header.",
             message: "{{description}}",
             severity: "error",
             formats: [oas2],

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3313,7 +3313,7 @@ const ruleset = {
         },
         LroAzureAsyncOperationHeader: {
             rpcGuidelineCode: "RPC-Async-V1-06",
-            description: "Azure-AsyncOperation header must be supported for all async long-running operations.",
+            description: "All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header.",
             message: "{{description}}",
             severity: "error",
             formats: [oas2],

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -3313,16 +3313,13 @@ const ruleset = {
         },
         LroAzureAsyncOperationHeader: {
             rpcGuidelineCode: "RPC-Async-V1-06",
-            description: "Azure-AsyncOperation header must be supported for all async operations that return 202.",
+            description: "Azure-AsyncOperation header must be supported for all async long-running operations.",
             message: "{{description}}",
             severity: "error",
             formats: [oas2],
-            given: "$.paths[*][*].responses[?(@property == '202')]",
+            given: "$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers[?(@property !== 'Azure-AsyncOperation')]",
             then: {
-                function: hasHeader,
-                functionOptions: {
-                    name: "Azure-AsyncOperation",
-                },
+                function: falsy,
             },
         },
         LroLocationHeader: {

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -166,12 +166,9 @@ const ruleset: any = {
       message: "{{description}}",
       severity: "error",
       formats: [oas2],
-      given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers"],
+      given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*"],
       then: {
         function: lroAzureAsyncOperationHeader,
-        functionOptions: {
-          name: "Azure-AsyncOperation",
-        },
       },
     },
 

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -161,16 +161,14 @@ const ruleset: any = {
     // RPC Code: RPC-Async-V1-06
     LroAzureAsyncOperationHeader: {
       rpcGuidelineCode: "RPC-Async-V1-06",
-      description: "Azure-AsyncOperation header must be supported for all async operations that return 202.",
+      description: "Azure-AsyncOperation header must be supported for all async long-running operations.",
       message: "{{description}}",
       severity: "error",
       formats: [oas2],
-      given: "$.paths[*][*].responses[?(@property == '202')]",
+      given:
+        "$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers[?(@property !== 'Azure-AsyncOperation')]",
       then: {
-        function: hasheader,
-        functionOptions: {
-          name: "Azure-AsyncOperation",
-        },
+        function: falsy,
       },
     },
 

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -161,14 +161,16 @@ const ruleset: any = {
     // RPC Code: RPC-Async-V1-06
     LroAzureAsyncOperationHeader: {
       rpcGuidelineCode: "RPC-Async-V1-06",
-      description: "All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header.",
+      description: "All long-running operations must include an `Azure-AsyncOperation' response header.",
       message: "{{description}}",
       severity: "error",
       formats: [oas2],
-      given:
-        "$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers[?(@property !== 'Azure-AsyncOperation')]",
+      given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*"],
       then: {
-        function: falsy,
+        function: hasheader,
+        functionOptions: {
+          name: "Azure-AsyncOperation",
+        },
       },
     },
 

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -15,6 +15,7 @@ import hasheader from "./functions/has-header"
 import httpsSupportedScheme from "./functions/https-supported-scheme"
 import { latestVersionOfCommonTypesMustBeUsed } from "./functions/latest-version-of-common-types-must-be-used"
 import locationMustHaveXmsMutability from "./functions/location-must-have-xms-mutability"
+import { lroAzureAsyncOperationHeader } from "./functions/lro-azure-async-operation-header"
 import validateOriginalUri from "./functions/lro-original-uri"
 import { lroPatch202 } from "./functions/lro-patch-202"
 import provisioningStateSpecifiedForLROPatch from "./functions/lro-patch-provisioning-state-specified"
@@ -165,9 +166,9 @@ const ruleset: any = {
       message: "{{description}}",
       severity: "error",
       formats: [oas2],
-      given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*"],
+      given: ["$[paths,'x-ms-paths'].*.*[?(@property === 'x-ms-long-running-operation' && @ === true)]^.responses.*.headers"],
       then: {
-        function: hasheader,
+        function: lroAzureAsyncOperationHeader,
         functionOptions: {
           name: "Azure-AsyncOperation",
         },

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -158,6 +158,22 @@ const ruleset: any = {
       },
     },
 
+    // RPC Code: RPC-Async-V1-06
+    LroAzureAsyncOperationHeader: {
+      rpcGuidelineCode: "RPC-Async-V1-06",
+      description: "Azure-AsyncOperation header must be supported for all async operations that return 202.",
+      message: "{{description}}",
+      severity: "error",
+      formats: [oas2],
+      given: "$.paths[*][*].responses[?(@property == '202')]",
+      then: {
+        function: hasheader,
+        functionOptions: {
+          name: "Azure-AsyncOperation",
+        },
+      },
+    },
+
     // RPC Code: RPC-Async-V1-07
     LroLocationHeader: {
       rpcGuidelineCode: "RPC-Async-V1-07",

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -161,7 +161,7 @@ const ruleset: any = {
     // RPC Code: RPC-Async-V1-06
     LroAzureAsyncOperationHeader: {
       rpcGuidelineCode: "RPC-Async-V1-06",
-      description: "Azure-AsyncOperation header must be supported for all async long-running operations.",
+      description: "All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header.",
       message: "{{description}}",
       severity: "error",
       formats: [oas2],

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -162,7 +162,7 @@ const ruleset: any = {
     // RPC Code: RPC-Async-V1-06
     LroAzureAsyncOperationHeader: {
       rpcGuidelineCode: "RPC-Async-V1-06",
-      description: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+      description: "All long-running operations must include an `Azure-AsyncOperation` response header.",
       message: "{{description}}",
       severity: "error",
       formats: [oas2],

--- a/packages/rulesets/src/spectral/functions/lro-azure-async-operation-header.ts
+++ b/packages/rulesets/src/spectral/functions/lro-azure-async-operation-header.ts
@@ -2,7 +2,7 @@ export const lroAzureAsyncOperationHeader = (headers: any, _opts: any, ctx: any)
   if (!Object.keys(headers).includes("headers") || !Object.keys(headers.headers).includes("Azure-AsyncOperation")) {
     return [
       {
-        message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+        message: "All long-running operations must include an `Azure-AsyncOperation` response header.",
         path: ctx.path.concat("headers"),
       },
     ]

--- a/packages/rulesets/src/spectral/functions/lro-azure-async-operation-header.ts
+++ b/packages/rulesets/src/spectral/functions/lro-azure-async-operation-header.ts
@@ -1,13 +1,11 @@
 export const lroAzureAsyncOperationHeader = (headers: any, _opts: any, ctx: any) => {
-  if (headers) {
-    if (headers === null || !Object.keys(headers).includes("Azure-AsyncOperation")) {
-      return [
-        {
-          message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
-          path: ctx.path,
-        },
-      ]
-    }
+  if (!Object.keys(headers).includes("headers") || !Object.keys(headers.headers).includes("Azure-AsyncOperation")) {
+    return [
+      {
+        message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+        path: ctx.path.concat("headers"),
+      },
+    ]
   }
   return []
 }

--- a/packages/rulesets/src/spectral/functions/lro-azure-async-operation-header.ts
+++ b/packages/rulesets/src/spectral/functions/lro-azure-async-operation-header.ts
@@ -1,0 +1,13 @@
+export const lroAzureAsyncOperationHeader = (headers: any, _opts: any, ctx: any) => {
+  if (headers) {
+    if (headers === null || !Object.keys(headers).includes("Azure-AsyncOperation")) {
+      return [
+        {
+          message: "All long-running operations must include an `Azure-AsyncOperation' response header.",
+          path: ctx.path,
+        },
+      ]
+    }
+  }
+  return []
+}

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
   return linter
 })
 
-const ERROR_MESSAGE = "All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header."
+const ERROR_MESSAGE = "All long-running operations must include an `Azure-AsyncOperation' response header."
 
 test("LroAzureAsyncOperationHeader should find no errors", () => {
   const myOpenApiDocument = {
@@ -18,15 +18,9 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
         get: {
           operationId: "foo_get",
           responses: {
-            200: {
-              description: "Success",
-            },
             202: {
               description: "Accepted",
-              // no header scenario
-            },
-            default: {
-              description: "Error",
+              // no header scenario and no x-ms-long-running-operation
             },
           },
         },
@@ -34,9 +28,6 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
           operationId: "foo_post",
           "x-ms-long-running-operation": true,
           responses: {
-            200: {
-              description: "Success",
-            },
             202: {
               description: "Accepted",
               headers: {
@@ -45,9 +36,6 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
                   type: "string",
                 },
               },
-            },
-            default: {
-              description: "Error",
             },
           },
         },
@@ -63,20 +51,6 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
                   type: "string",
                 },
               },
-            },
-            default: {
-              description: "Error",
-            },
-          },
-        },
-        delete: {
-          operationId: "foo_put",
-          responses: {
-            204: {
-              description: "No x-ms-long-running-operation ",
-            },
-            default: {
-              description: "Error",
             },
           },
         },
@@ -97,9 +71,6 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
           operationId: "foo_get",
           "x-ms-long-running-operation": true,
           responses: {
-            200: {
-              description: "Success",
-            },
             202: {
               description: "Accepted",
               headers: {
@@ -108,9 +79,6 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
                   type: "string",
                 },
               },
-            },
-            default: {
-              description: "Error",
             },
           },
         },
@@ -118,20 +86,8 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
           operationId: "foo_post",
           "x-ms-long-running-operation": false,
           responses: {
-            200: {
-              description: "Success",
-            },
             202: {
-              description: "Empty header case",
-              headers: {
-                Location: {
-                  description: "No Azure-AsyncOperation header",
-                  type: "string",
-                },
-              },
-            },
-            default: {
-              description: "Error",
+              description: "No header case",
             },
           },
         },
@@ -139,32 +95,11 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
           operationId: "foo_put",
           "x-ms-long-running-operation": true,
           responses: {
-            200: {
-              description: "Success",
-            },
             202: {
               description: "Accepted",
               headers: {
                 "azure-asyncOperation1": {
                   description: "check the wrong wording",
-                  type: "string",
-                },
-              },
-            },
-            default: {
-              description: "Error",
-            },
-          },
-        },
-        delete: {
-          operationId: "foo_put",
-          "x-ms-long-running-operation": true,
-          responses: {
-            202: {
-              description: "Accepted",
-              headers: {
-                "azure-asyncOperation": {
-                  description: "Check case sensitive scenario",
                   type: "string",
                 },
               },
@@ -175,12 +110,10 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
     },
   }
   return linter.run(myOpenApiDocument).then((results) => {
-    expect(results.length).toBe(3)
-    expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers.Location")
+    expect(results.length).toBe(2)
+    expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers")
     expect(results[0].message).toEqual(ERROR_MESSAGE)
-    expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers.azure-asyncOperation1")
+    expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
     expect(results[1].message).toEqual(ERROR_MESSAGE)
-    expect(results[2].path.join(".")).toBe("paths./foo1/operations.delete.responses.202.headers.azure-asyncOperation")
-    expect(results[2].message).toEqual(ERROR_MESSAGE)
   })
 })

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
   return linter
 })
 
-const ERROR_MESSAGE = "All long-running operations must include an `Azure-AsyncOperation' response header."
+const ERROR_MESSAGE = "All long-running operations must include an `Azure-AsyncOperation` response header."
 
 test("LroAzureAsyncOperationHeader should find no errors", () => {
   const myOpenApiDocument = {

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -106,13 +106,30 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
             },
           },
         },
+        delete: {
+          operationId: "foo_delete",
+          "x-ms-long-running-operation": true,
+          responses: {
+            202: {
+              description: "Accepted",
+              headers: {
+                "azure-asyncOperation": {
+                  description: "check the camel case",
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
       },
     },
   }
   return linter.run(myOpenApiDocument).then((results) => {
-    expect(results.length).toBe(2)
+    expect(results.length).toBe(3)
     expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers")
     expect(results[0].message).toEqual(ERROR_MESSAGE)
+    expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
+    expect(results[1].message).toEqual(ERROR_MESSAGE)
     expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
     expect(results[1].message).toEqual(ERROR_MESSAGE)
   })

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
   return linter
 })
 
-const ERROR_MESSAGE = "Azure-AsyncOperation header must be supported for all async operations that return 202."
+const ERROR_MESSAGE = "Azure-AsyncOperation header must be supported for all async long-running operations."
 
 test("LroAzureAsyncOperationHeader should find no errors", () => {
   const myOpenApiDocument = {

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -1,0 +1,158 @@
+import { Spectral } from "@stoplight/spectral-core"
+import linterForRule from "./utils"
+
+let linter: Spectral
+
+beforeAll(async () => {
+  linter = await linterForRule("LroAzureAsyncOperationHeader")
+  return linter
+})
+
+const ERROR_MESSAGE = "Azure-AsyncOperation header must be supported for all async operations that return 202."
+
+test("LroAzureAsyncOperationHeader should find no errors", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/foo1/operations": {
+        get: {
+          operationId: "foo_get",
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {
+                "Azure-AsyncOperation": {
+                  description: "The URL where the status of the asynchronous operation can be checked.",
+                  type: "string",
+                },
+              },
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+        post: {
+          operationId: "foo_post",
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {
+                "Azure-asyncoperation": {
+                  description: "The URL where the status of the asynchronous operation can be checked.",
+                  type: "string",
+                },
+              },
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+        put: {
+          operationId: "foo_put",
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {
+                "azure-asyncOperation": {
+                  description: "The URL where the status of the asynchronous operation can be checked.",
+                  type: "string",
+                },
+              },
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(0)
+  })
+})
+
+test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperation header", () => {
+  const myOpenApiDocument = {
+    swagger: "2.0",
+    paths: {
+      "/foo1/operations": {
+        get: {
+          operationId: "foo_get",
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {
+                Location: {
+                  description: "The URL where the status of the asynchronous operation can be checked.",
+                  type: "string",
+                },
+              },
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+        post: {
+          operationId: "foo_post",
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {},
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+        put: {
+          operationId: "foo_put",
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {
+                azureasyncOperation: {
+                  description: "The URL where the status of the asynchronous operation can be checked.",
+                  type: "string",
+                },
+              },
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+      },
+    },
+  }
+  return linter.run(myOpenApiDocument).then((results) => {
+    expect(results.length).toBe(3)
+    expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers")
+    expect(results[0].message).toEqual(ERROR_MESSAGE)
+    expect(results[1].path.join(".")).toBe("paths./foo1/operations.post.responses.202.headers")
+    expect(results[1].message).toEqual(ERROR_MESSAGE)
+    expect(results[2].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
+    expect(results[2].message).toEqual(ERROR_MESSAGE)
+  })
+})

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -84,7 +84,7 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
         },
         post: {
           operationId: "foo_post",
-          "x-ms-long-running-operation": false,
+          "x-ms-long-running-operation": true,
           responses: {
             202: {
               description: "No header case",
@@ -125,12 +125,14 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
     },
   }
   return linter.run(myOpenApiDocument).then((results) => {
-    expect(results.length).toBe(3)
+    expect(results.length).toBe(4)
     expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers")
     expect(results[0].message).toEqual(ERROR_MESSAGE)
-    expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
+    expect(results[1].path.join(".")).toBe("paths./foo1/operations.post.responses.202")
     expect(results[1].message).toEqual(ERROR_MESSAGE)
-    expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
-    expect(results[1].message).toEqual(ERROR_MESSAGE)
+    expect(results[2].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
+    expect(results[2].message).toEqual(ERROR_MESSAGE)
+    expect(results[3].path.join(".")).toBe("paths./foo1/operations.delete.responses.202.headers")
+    expect(results[3].message).toEqual(ERROR_MESSAGE)
   })
 })

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -23,6 +23,22 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
             },
             202: {
               description: "Accepted",
+              // no header scenario
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+        post: {
+          operationId: "foo_post",
+          "x-ms-long-running-operation": true,
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
               headers: {
                 "Azure-AsyncOperation": {
                   description: "The URL where the status of the asynchronous operation can be checked.",
@@ -35,16 +51,14 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
             },
           },
         },
-        post: {
-          operationId: "foo_post",
+        put: {
+          operationId: "foo_put",
+          "x-ms-long-running-operation": true,
           responses: {
-            200: {
-              description: "Success",
-            },
-            202: {
+            204: {
               description: "Accepted",
               headers: {
-                "Azure-asyncoperation": {
+                "Azure-AsyncOperation": {
                   description: "The URL where the status of the asynchronous operation can be checked.",
                   type: "string",
                 },
@@ -55,20 +69,11 @@ test("LroAzureAsyncOperationHeader should find no errors", () => {
             },
           },
         },
-        put: {
+        delete: {
           operationId: "foo_put",
           responses: {
-            200: {
-              description: "Success",
-            },
-            202: {
-              description: "Accepted",
-              headers: {
-                "azure-asyncOperation": {
-                  description: "The URL where the status of the asynchronous operation can be checked.",
-                  type: "string",
-                },
-              },
+            204: {
+              description: "No x-ms-long-running-operation ",
             },
             default: {
               description: "Error",
@@ -90,6 +95,7 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
       "/foo1/operations": {
         get: {
           operationId: "foo_get",
+          "x-ms-long-running-operation": true,
           responses: {
             200: {
               description: "Success",
@@ -98,7 +104,7 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
               description: "Accepted",
               headers: {
                 Location: {
-                  description: "The URL where the status of the asynchronous operation can be checked.",
+                  description: "No Azure-AsyncOperation header",
                   type: "string",
                 },
               },
@@ -110,30 +116,16 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
         },
         post: {
           operationId: "foo_post",
+          "x-ms-long-running-operation": false,
           responses: {
             200: {
               description: "Success",
             },
             202: {
-              description: "Accepted",
-              headers: {},
-            },
-            default: {
-              description: "Error",
-            },
-          },
-        },
-        put: {
-          operationId: "foo_put",
-          responses: {
-            200: {
-              description: "Success",
-            },
-            202: {
-              description: "Accepted",
+              description: "Empty header case",
               headers: {
-                azureasyncOperation: {
-                  description: "The URL where the status of the asynchronous operation can be checked.",
+                Location: {
+                  description: "No Azure-AsyncOperation header",
                   type: "string",
                 },
               },
@@ -143,16 +135,52 @@ test("LroAzureAsyncOperationHeader should find errors with no Azure-AsyncOperati
             },
           },
         },
+        put: {
+          operationId: "foo_put",
+          "x-ms-long-running-operation": true,
+          responses: {
+            200: {
+              description: "Success",
+            },
+            202: {
+              description: "Accepted",
+              headers: {
+                "azure-asyncOperation1": {
+                  description: "check the wrong wording",
+                  type: "string",
+                },
+              },
+            },
+            default: {
+              description: "Error",
+            },
+          },
+        },
+        delete: {
+          operationId: "foo_put",
+          "x-ms-long-running-operation": true,
+          responses: {
+            202: {
+              description: "Accepted",
+              headers: {
+                "azure-asyncOperation": {
+                  description: "Check case sensitive scenario",
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
       },
     },
   }
   return linter.run(myOpenApiDocument).then((results) => {
     expect(results.length).toBe(3)
-    expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers")
+    expect(results[0].path.join(".")).toBe("paths./foo1/operations.get.responses.202.headers.Location")
     expect(results[0].message).toEqual(ERROR_MESSAGE)
-    expect(results[1].path.join(".")).toBe("paths./foo1/operations.post.responses.202.headers")
+    expect(results[1].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers.azure-asyncOperation1")
     expect(results[1].message).toEqual(ERROR_MESSAGE)
-    expect(results[2].path.join(".")).toBe("paths./foo1/operations.put.responses.202.headers")
+    expect(results[2].path.join(".")).toBe("paths./foo1/operations.delete.responses.202.headers.azure-asyncOperation")
     expect(results[2].message).toEqual(ERROR_MESSAGE)
   })
 })

--- a/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
+++ b/packages/rulesets/src/spectral/test/lro-azure-async-operation-header.test.ts
@@ -8,7 +8,7 @@ beforeAll(async () => {
   return linter
 })
 
-const ERROR_MESSAGE = "Azure-AsyncOperation header must be supported for all async long-running operations."
+const ERROR_MESSAGE = "All long-running operations that define the `headers` field must include an `Azure-AsyncOperation` response header."
 
 test("LroAzureAsyncOperationHeader should find no errors", () => {
   const myOpenApiDocument = {


### PR DESCRIPTION
LroAzureAsyncOperationHeader rule checks "Azure-AsyncOperation" header must be added for all async operations.

This checks for the absence of headers, including the "Azure-AsyncOperation" header.

[WorkItem](https://msazure.visualstudio.com/One/_workitems/edit/29424555)
