### PR TITLE
Add linter rule to suggest the scope parameter

### DIFF
--- a/docs/suggest-scope-parameter.md
+++ b/docs/suggest-scope-parameter.md
@@ -1,0 +1,35 @@
+# SuggestScopeParameter
+
+## Category
+
+ARM Warning
+
+## Applies to
+
+ARM OpenAPI(swagger) specs
+
+## Related ARM Guideline Code
+
+- N/a
+
+## Description
+
+OpenAPI authors can use the `scope` path parameter to indicate that an API is applicable to various scopes (Tenant,
+Management Group, Subscription, Resource Group, etc.) rather than explicitly defining each scope in the spec.
+
+## How to fix
+
+Remove all explicitly-scoped paths that only vary in scope and create a path with the `scope` parameter.
+
+Example of explicitly-scoped paths that only vary in scope:
+
+2. Explicitly-scoped path (by subscription)
+   **`/subscriptions/{subscriptionId}`**`/providers/Microsoft.Bakery/breads`
+
+3. Explicitly-scoped path (by resource group):
+   **`/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}`**`/providers/Microsoft.Bakery/breads`
+
+These two paths can be replaced with a single path that uses the `scope` parameter:
+
+1. Path with scope parameter:
+   **`/{scope}`**`/providers/Microsoft.Bakery/breads`

--- a/packages/rulesets/src/native/legacyRules/GetCollectionResponseSchema.ts
+++ b/packages/rulesets/src/native/legacyRules/GetCollectionResponseSchema.ts
@@ -14,7 +14,7 @@ rules.push({
   appliesTo_JsonQuery: "$",
   *run(doc, node, path, ctx) {
     const msg =
-      'The response in the GET collection operation "{0}" does not match the response definition in the individual GET  operation "{1}" .'
+      'The response in the GET collection operation "{0}" does not match the response definition in the individual GET operation "{1}".'
     /**
      * 1 travel all resources and find all the resources that have a collection get
      *   - by searching all the models return by a get operation and verify the schema

--- a/packages/rulesets/src/spectral/az-arm.ts
+++ b/packages/rulesets/src/spectral/az-arm.ts
@@ -56,6 +56,8 @@ import { validatePatchBodyParamProperties } from "./functions/validate-patch-bod
 import withXmsResource from "./functions/with-xms-resource"
 import verifyXMSLongRunningOperationProperty from "./functions/xms-long-running-operation-property"
 import xmsPageableForListCalls from "./functions/xms-pageable-for-list-calls"
+import { resolve } from "path"
+import suggestScopeParameter from "./functions/suggest-scope-parameter"
 
 const ruleset: any = {
   extends: [common],
@@ -316,6 +318,20 @@ const ruleset: any = {
       ],
       then: {
         function: propertiesTypeObjectNoDefinition,
+      },
+    },
+
+    SuggestScopeParameter: {
+      description:
+        "Duplicate operations that vary only by scope can be defined with a single operation that has a scope parameter. This reduces the number of operations in the spec.",
+      severity: "warn",
+      stagingOnly: true,
+      message: "{{error}}",
+      resolved: true,
+      formats: [oas2],
+      given: ["$.paths", "$.x-ms-paths"],
+      then: {
+        function: suggestScopeParameter,
       },
     },
 

--- a/packages/rulesets/src/spectral/functions/suggest-scope-parameter.ts
+++ b/packages/rulesets/src/spectral/functions/suggest-scope-parameter.ts
@@ -1,0 +1,26 @@
+/**
+ * Suggests combining paths that differ only in scope by defining a scope parameter.
+ *
+ * This function checks if the given path can be combined with other paths in the Swagger document
+ * by introducing a scope parameter. It returns suggestions for paths that differ only in scope.
+ */
+const suggestScopeParameter = (path: any, _opts: any, ctx: any) => {
+  const swagger = ctx?.documentInventory?.resolved
+
+  if (path === null || typeof path !== "string" || path.length === 0 || swagger === null || path.startsWith("{scope}")) {
+    return []
+  }
+
+  const resourceTypeName = path.substring(path.lastIndexOf("/providers"))
+
+  const otherPaths = Object.keys(swagger.paths).filter((p: string) => p !== path && p.endsWith(resourceTypeName))
+
+  return otherPaths.map((p) => {
+    return {
+      message: `Path "${p}" differs from path "${path}" only in scope. These paths can be combined by defining a scope parameter.`,
+      path: ctx.path,
+    }
+  })
+}
+
+export default suggestScopeParameter


### PR DESCRIPTION
Add a rule that helps disambiguate paths that share the same `/providers` suffix by suggesting the use of the `scope` parameter.