### PR TITLE
Fix RequiredPropertiesMissingInResourceModel to account get and list …

### DIFF
--- a/packages/rulesets/CHANGELOG.md
+++ b/packages/rulesets/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patches
 
 - [AllTrackedResourcesMustHaveDelete][TrackedResourcePatchOperation] Skip the api paths if it has PrivateEndpointConnectionProxy
+- [RequiredPropertiesMissingInResourceModel] Updated the rule to also account for both GET and LIST properties, and also modified the `getProperties` helper method to include LIST.
 
 ### Patches
 

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2614,10 +2614,17 @@ var Workspace;
             return [];
         }
         let result = {};
-        const model = source.value;
+        let model = source.value;
+        if (model.properties && model.properties.value && model.properties.value.items && model.properties.value.items.$ref) {
+            const referenceSchema = resolveRef(createEnhancedSchema(model.properties.value.items, source.file), inventory);
+            if (referenceSchema && referenceSchema.value && referenceSchema.value.properties) {
+                model = referenceSchema.value;
+            }
+        }
         if (model.properties) {
             for (const propertyName of Object.keys(model.properties)) {
-                result[propertyName] = createEnhancedSchema(model.properties[propertyName], source.file);
+                const propertySchema = createEnhancedSchema(model.properties[propertyName], source.file);
+                result[propertyName] = propertySchema;
             }
         }
         if (model.allOf) {

--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2604,6 +2604,7 @@ var Workspace;
     }
     Workspace.getProperty = getProperty;
     function getProperties(schema, inventory) {
+        var _a, _b, _c;
         let source = schema;
         const visited = new Set();
         while (source.value && source.value.$ref && !visited.has(source.value)) {
@@ -2615,7 +2616,7 @@ var Workspace;
         }
         let result = {};
         let model = source.value;
-        if (model.properties && model.properties.value && model.properties.value.items && model.properties.value.items.$ref) {
+        if ((_c = (_b = (_a = model.properties) === null || _a === void 0 ? void 0 : _a.value) === null || _b === void 0 ? void 0 : _b.items) === null || _c === void 0 ? void 0 : _c.$ref) {
             const referenceSchema = resolveRef(createEnhancedSchema(model.properties.value.items, source.file), inventory);
             if (referenceSchema && referenceSchema.value && referenceSchema.value.properties) {
                 model = referenceSchema.value;
@@ -2623,8 +2624,7 @@ var Workspace;
         }
         if (model.properties) {
             for (const propertyName of Object.keys(model.properties)) {
-                const propertySchema = createEnhancedSchema(model.properties[propertyName], source.file);
-                result[propertyName] = propertySchema;
+                result[propertyName] = createEnhancedSchema(model.properties[propertyName], source.file);
             }
         }
         if (model.allOf) {

--- a/packages/rulesets/src/native/functions/arm-resource-validation.ts
+++ b/packages/rulesets/src/native/functions/arm-resource-validation.ts
@@ -149,7 +149,7 @@ export function* operationsAPIImplementation(openapiSection: any, options: {}, c
 
 export function* resourcesHaveRequiredProperties(openapiSection: any, options: {}, ctx: RuleContext) {
   const armHelper = new ArmHelper(ctx?.document, ctx?.specPath, ctx?.inventory!)
-  const allResources = armHelper.getAllResources(true)
+  const allResources = armHelper.getAllResources(true, false, true)
   for (const re of allResources) {
     const requiredProperties = ["name", "type", "id"]
     const properties = armHelper.getResourceProperties(re.modelName)

--- a/packages/rulesets/src/native/functions/arm-resource-validation.ts
+++ b/packages/rulesets/src/native/functions/arm-resource-validation.ts
@@ -149,7 +149,7 @@ export function* operationsAPIImplementation(openapiSection: any, options: {}, c
 
 export function* resourcesHaveRequiredProperties(openapiSection: any, options: {}, ctx: RuleContext) {
   const armHelper = new ArmHelper(ctx?.document, ctx?.specPath, ctx?.inventory!)
-  const allResources = armHelper.getAllResources()
+  const allResources = armHelper.getAllResources(true)
   for (const re of allResources) {
     const requiredProperties = ["name", "type", "id"]
     const properties = armHelper.getResourceProperties(re.modelName)

--- a/packages/rulesets/src/native/rulesets/arm.ts
+++ b/packages/rulesets/src/native/rulesets/arm.ts
@@ -190,6 +190,4 @@ export const armRuleset: IRuleSet = {
     },
   },
 }
-
-
 export default armRuleset

--- a/packages/rulesets/src/native/rulesets/arm.ts
+++ b/packages/rulesets/src/native/rulesets/arm.ts
@@ -190,4 +190,6 @@ export const armRuleset: IRuleSet = {
     },
   },
 }
+
+
 export default armRuleset

--- a/packages/rulesets/src/native/tests/migrated-arm-rule-tests.ts
+++ b/packages/rulesets/src/native/tests/migrated-arm-rule-tests.ts
@@ -32,7 +32,7 @@ describe("IndividualAzureTests", () => {
     const fileNames = ["ext-resource-validation.json"]
     const ruleName = "RequiredPropertiesMissingInResourceModel"
     const messages: LintResultMessage[] = await collectTestMessagesFromValidator(fileNames, OpenApiTypes.arm, ruleName)
-    assertValidationRuleCount(messages, ruleName, 1)
+    assertValidationRuleCount(messages, ruleName, 3)
   })
 
   test("[positive] required properties in resource model with reference", async () => {

--- a/packages/rulesets/src/native/tests/resources/ext-resource-validation.json
+++ b/packages/rulesets/src/native/tests/resources/ext-resource-validation.json
@@ -94,7 +94,7 @@
       }
     },
     "/providers/Microsoft.Cache/locations/{location}/publishers": {
-      "put": {
+      "get": {
         "tags": [
           "extensions"
         ],
@@ -119,7 +119,7 @@
       }
     },
     "/providers/Microsoft.Cache/locations/{location}/Connectors": {
-      "put": {
+      "get": {
         "tags": [
           "extensions"
         ],

--- a/packages/rulesets/src/native/tests/resources/ext-resource-validation.json
+++ b/packages/rulesets/src/native/tests/resources/ext-resource-validation.json
@@ -92,6 +92,56 @@
           }
         }
       }
+    },
+    "/providers/Microsoft.Cache/locations/{location}/publishers": {
+      "put": {
+        "tags": [
+          "extensions"
+        ],
+        "operationId": "ExtensionPublisher_List",
+        "description": "Gets all Extension publishers based on the location",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParamterer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ExtensionPublisherListResult"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Cache/locations/{location}/Connectors": {
+      "put": {
+        "tags": [
+          "extensions"
+        ],
+        "operationId": "ExtensionPublisher_List",
+        "description": "Gets all Extension publishers based on the location",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParamterer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ListConnectorsSuccessResponse"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -116,6 +166,92 @@
           "$ref": "#/definitions/Resource"
         }
       ]
+    },
+    "ExtensionPublisherListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ExtensionPublisher"
+          },
+          "description": "The list of extension publishers.",
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page of extension publishers."
+        }
+      },
+      "description": "The List of Extension Publishers."
+    },
+    "ExtensionPublisher": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the extension publisher."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the extension publisher."
+        }
+      },
+      "description": "Describes an Extension Publisher."
+    },
+    "ListConnectorsSuccessResponse": {
+      "description": "Result of GET request to list connectors in the cluster of a confluent organization",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of connectors in a cluster of a confluent organization",
+          "type": "array",
+          "x-ms-identifiers": [],
+          "items": {
+            "$ref": "#/definitions/ConnectorResource"
+          }
+        },
+        "nextLink": {
+          "description": "URL to get the next set of connectors records if there are any.",
+          "type": "string"
+        }
+      }
+    },
+    "ConnectorResource": {
+      "description": "Details of connector record",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource",
+          "description": "The resource model definition for an Azure Resource Manager proxy resource."
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "properties": {
+        "name": {
+          "description": "Display name of the connector",
+          "type": "string",
+          "readOnly": true
+        },
+        "properties": {
+          "description": "The properties of the Connector",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ConnectorResourceProperties"
+        }
+      }
+    },
+    "ConnectorResourceProperties": {
+      "description": "The resource properties of the Connector",
+      "type": "object",
+      "properties": {
+        "connectorId": {
+          "description": "Connector Id",
+          "type": "string"
+        }
+      }
     }
   },
   "parameters": {

--- a/packages/rulesets/src/native/utilities/arm-helper.ts
+++ b/packages/rulesets/src/native/utilities/arm-helper.ts
@@ -280,7 +280,7 @@ export class ArmHelper {
     )
   }
 
-  public getAllResources(includeGet: boolean = false, useArmResources: boolean = true) {
+  public getAllResources(includeGet: boolean = false, useArmResources: boolean = true, includeListOperationPath: boolean = false) {
     if (useArmResources && this.armResources) {
       return this.armResources
     }
@@ -293,13 +293,15 @@ export class ArmHelper {
     }
     const localResourceModels = this.resources.filter((re) => re.specPath === this.specPath)
     const resWithXmsRes = localResourceModels.filter(
-      (re) => this.XmsResources.has(re.modelName) && 
-      !this.BaseResourceModelNames.includes(re.modelName.toLowerCase()),
+      (re) => this.XmsResources.has(re.modelName) && !this.BaseResourceModelNames.includes(re.modelName.toLowerCase()),
     )
     const resWithPutOrPatch = includeGet
       ? localResourceModels.filter((re) =>
           re.operations.some(
-            (op) => (op.httpMethod === "get" && !isListOperationPath(op.apiPath)) || op.httpMethod === "put" || op.httpMethod == "patch",
+            (op) =>
+              (op.httpMethod === "get" && (includeListOperationPath ? true : !isListOperationPath(op.apiPath))) ||
+              op.httpMethod === "put" ||
+              op.httpMethod === "patch",
           ),
         )
       : localResourceModels.filter((re) => re.operations.some((op) => op.httpMethod === "put" || op.httpMethod == "patch"))

--- a/packages/rulesets/src/native/utilities/arm-helper.ts
+++ b/packages/rulesets/src/native/utilities/arm-helper.ts
@@ -293,7 +293,8 @@ export class ArmHelper {
     }
     const localResourceModels = this.resources.filter((re) => re.specPath === this.specPath)
     const resWithXmsRes = localResourceModels.filter(
-      (re) => this.XmsResources.has(re.modelName) && !this.BaseResourceModelNames.includes(re.modelName.toLowerCase()),
+      (re) => this.XmsResources.has(re.modelName) && 
+      !this.BaseResourceModelNames.includes(re.modelName.toLowerCase()),
     )
     const resWithPutOrPatch = includeGet
       ? localResourceModels.filter((re) =>

--- a/packages/rulesets/src/native/utilities/swagger-workspace.ts
+++ b/packages/rulesets/src/native/utilities/swagger-workspace.ts
@@ -85,7 +85,7 @@ export namespace Workspace {
     let result: { [key: string]: EnhancedSchema } = {}
     let model = source.value
     // for list call, the properties are in the value.items.$ref
-    if (model.properties && model.properties.value && model.properties.value.items && model.properties.value.items.$ref) {
+    if (model.properties?.value?.items?.$ref) {
       const referenceSchema = resolveRef(createEnhancedSchema(model.properties.value.items, source.file), inventory)
       if (referenceSchema && referenceSchema.value && referenceSchema.value.properties) {
         model = referenceSchema.value

--- a/packages/rulesets/src/native/utilities/swagger-workspace.ts
+++ b/packages/rulesets/src/native/utilities/swagger-workspace.ts
@@ -72,8 +72,7 @@ export namespace Workspace {
     }
     return undefined
   }
-
-    export function getProperties(schema: EnhancedSchema, inventory: ISwaggerInventory) {
+  export function getProperties(schema: EnhancedSchema, inventory: ISwaggerInventory) {
     let source = schema
     const visited = new Set<any>()
     while (source.value && source.value.$ref && !visited.has(source.value)) {
@@ -83,18 +82,26 @@ export namespace Workspace {
     if (!source || !source.value) {
       return []
     }
-    let result:{[key:string]:EnhancedSchema} = {}
-    const model = source.value
+    let result: { [key: string]: EnhancedSchema } = {}
+    let model = source.value
+    // for list call, the properties are in the value.items.$ref
+    if (model.properties && model.properties.value && model.properties.value.items && model.properties.value.items.$ref) {
+      const referenceSchema = resolveRef(createEnhancedSchema(model.properties.value.items, source.file), inventory)
+      if (referenceSchema && referenceSchema.value && referenceSchema.value.properties) {
+        model = referenceSchema.value
+      }
+    }
     if (model.properties) {
-      for (const propertyName of Object.keys(model.properties)){
-        result[propertyName] = createEnhancedSchema(model.properties[propertyName], source.file)
+      for (const propertyName of Object.keys(model.properties)) {
+        const propertySchema = createEnhancedSchema(model.properties[propertyName], source.file)
+        result[propertyName] = propertySchema
       }
     }
     if (model.allOf) {
       for (const element of model.allOf) {
         const properties: any = getProperties({ file: source.file, value: element }, inventory)
         if (properties) {
-          result = {...properties,...result}
+          result = { ...properties, ...result }
         }
       }
     }

--- a/packages/rulesets/src/native/utilities/swagger-workspace.ts
+++ b/packages/rulesets/src/native/utilities/swagger-workspace.ts
@@ -93,8 +93,7 @@ export namespace Workspace {
     }
     if (model.properties) {
       for (const propertyName of Object.keys(model.properties)) {
-        const propertySchema = createEnhancedSchema(model.properties[propertyName], source.file)
-        result[propertyName] = propertySchema
+        result[propertyName] = createEnhancedSchema(model.properties[propertyName], source.file)
       }
     }
     if (model.allOf) {


### PR DESCRIPTION
The `RequiredPropertiesMissingInResourceModel` rule did not account for GET and LIST calls. This PR resolves the issue and also updates the `getProperties` helper method to include the LIST call pattern when fetching properties.