### PR TITLE
bump version rulesets to 2.1.7 and autorest to 2.2.4

### DIFF
--- a/packages/azure-openapi-validator/autorest/package.json
+++ b/packages/azure-openapi-validator/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Azure OpenAPI Validator",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/rulesets/package.json
+++ b/packages/rulesets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/openapi-validator-rulesets",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Azure OpenAPI Validator",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Wanted to run the production pipeline to release few fixes mentioned here -[Changes going out on 3/5](onenote:https://microsoft.sharepoint.com/teams/AzureResourceManager74/Shared%20Documents/RP%20for%20RP/RPaaS%20Team%20Onenote/ARM%20RPC%20Governance.one#March%202025%20release%20notes&section-id={B8ACEAAD-038F-469E-9DEA-BDC3CD8E1D08}&page-id={89F91E54-AA32-4D91-AFCD-3B41600C036B}&object-id={FB0A233C-2B43-0C9C-083A-DF3E88535FC7}&2D)  ([Web view](https://microsoft.sharepoint.com/teams/AzureResourceManager74/_layouts/OneNote.aspx?id=%2Fteams%2FAzureResourceManager74%2FShared%20Documents%2FRP%20for%20RP%2FRPaaS%20Team%20Onenote&wd=target%28ARM%20RPC%20Governance.one%7CB8ACEAAD-038F-469E-9DEA-BDC3CD8E1D08%2FMarch%202025%20release%20notes%7C89F91E54-AA32-4D91-AFCD-3B41600C036B%2F%29))
So did a version bump.