### PR TITLE
Skip/grant exception to models in common-types for RequiredProperties…

### DIFF
--- a/packages/rulesets/generated/spectral/az-arm.js
+++ b/packages/rulesets/generated/spectral/az-arm.js
@@ -2652,7 +2652,12 @@ var Workspace;
         }
         let result = {};
         let model = source.value;
-        if ((_c = (_b = (_a = model.properties) === null || _a === void 0 ? void 0 : _a.value) === null || _b === void 0 ? void 0 : _b.items) === null || _c === void 0 ? void 0 : _c.$ref) {
+        const reference = (_c = (_b = (_a = model.properties) === null || _a === void 0 ? void 0 : _a.value) === null || _b === void 0 ? void 0 : _b.items) === null || _c === void 0 ? void 0 : _c.$ref;
+        if ((reference === null || reference === void 0 ? void 0 : reference.includes("/common-types/")) && (reference === null || reference === void 0 ? void 0 : reference.includes("/types.json#/definitions/"))) {
+            result["common-types"] = createEnhancedSchema("", "");
+            return result;
+        }
+        else if (reference) {
             const referenceSchema = resolveRef(createEnhancedSchema(model.properties.value.items, source.file), inventory);
             if (referenceSchema && referenceSchema.value && referenceSchema.value.properties) {
                 model = referenceSchema.value;

--- a/packages/rulesets/src/native/functions/arm-resource-validation.ts
+++ b/packages/rulesets/src/native/functions/arm-resource-validation.ts
@@ -180,6 +180,10 @@ export function* resourcesHaveRequiredProperties(openapiSection: any, options: {
   for (const re of allResources) {
     const requiredProperties = ["name", "type", "id"]
     const properties = armHelper.getResourceProperties(re.modelName)
+    // skip for common-types
+    if (properties["common-types"]) {
+      continue
+    }
     for (const propName of requiredProperties) {
       const prop = properties[propName]
       if (!prop || armHelper.getAttribute(prop, "readOnly")?.value !== true) {

--- a/packages/rulesets/src/native/tests/resources/ext-resource-validation-with-reference.json
+++ b/packages/rulesets/src/native/tests/resources/ext-resource-validation-with-reference.json
@@ -54,6 +54,30 @@
           }
         }
       }
+    },
+    "/providers/Microsoft.Cache/Redis/{resourceName}/operations": {
+      "get": {
+        "tags": [
+          "OperationStatusResult"
+        ],
+        "operationId": "OperationStatusResult_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParamterer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationStatusResultList"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -63,6 +87,29 @@
           "$ref": "./common-types/types.json#/definitions/Resource"
         }
       ]
+    },
+    "OperationStatusResultList": {
+      "description": "The operations list. It contains an URL link to get the next set of results.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./common-types/types.json#/definitions/OperationStatusResult"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "description": "List of operations",
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to get the next set of operation list results (if there are any).",
+          "readOnly": true
+        }
+      }
     }
   },
   "parameters": {

--- a/packages/rulesets/src/native/utilities/swagger-workspace.ts
+++ b/packages/rulesets/src/native/utilities/swagger-workspace.ts
@@ -85,7 +85,13 @@ export namespace Workspace {
     let result: { [key: string]: EnhancedSchema } = {}
     let model = source.value
     // for list call, the properties are in the value.items.$ref
-    if (model.properties?.value?.items?.$ref) {
+    // skip for models in common-types
+    const reference = model.properties?.value?.items?.$ref
+    if (reference?.includes("/common-types/") && reference?.includes("/types.json#/definitions/")) {
+       result["common-types"] = createEnhancedSchema("", "")
+       return result
+    }
+    else if(reference){
       const referenceSchema = resolveRef(createEnhancedSchema(model.properties.value.items, source.file), inventory)
       if (referenceSchema && referenceSchema.value && referenceSchema.value.properties) {
         model = referenceSchema.value


### PR DESCRIPTION
Skip/grant exception to models in common-types for RequiredPropertieMissingInResourceModel.

There are bunch of models in common-types that do not have required properties at top level & hence adding exception to that category to prevent from flagging for common-types.